### PR TITLE
Refactor: improve component spec

### DIFF
--- a/src/app/components/common/TextArea.tsx
+++ b/src/app/components/common/TextArea.tsx
@@ -10,7 +10,7 @@ const TextArea = forwardRef<HTMLTextAreaElement, TextAreaProps>((props, ref) => 
   const textRef = useRef<HTMLTextAreaElement>(null);
   const textCallbackRef = useForkRef(textRef, ref);
 
-  const handleResize = useCallback(() => {
+  const resize = useCallback(() => {
     if (textRef && textRef.current) {
       textRef.current.style.height = 'auto';
       textRef.current.style.height = `${textRef.current.scrollHeight}px`;
@@ -19,7 +19,7 @@ const TextArea = forwardRef<HTMLTextAreaElement, TextAreaProps>((props, ref) => 
 
   const handleChange = (e: ChangeEvent<HTMLTextAreaElement>) => {
     onChange?.(e);
-    handleResize();
+    resize();
   };
 
   return (
@@ -28,6 +28,7 @@ const TextArea = forwardRef<HTMLTextAreaElement, TextAreaProps>((props, ref) => 
       ref={textCallbackRef}
       className={clsx('resize-none textarea textarea-bordered', className)}
       onChange={handleChange}
+      value={value}
       rows={1}></textarea>
   );
 });

--- a/src/app/pages/BoardPage.tsx
+++ b/src/app/pages/BoardPage.tsx
@@ -1,11 +1,17 @@
+import { NoMatch } from 'app/components/routes';
+import { RouterParamKeys } from 'app/routes/router';
 import { BoardView } from 'kanbanwave';
-import { useLocation } from 'react-router-dom';
+import { useParams } from 'react-router-dom';
 
 const BoardPage = () => {
-  const location = useLocation();
-  const board = location.state?.board;
+  const { boardId } = useParams<RouterParamKeys>();
+
+  if (boardId == null) {
+    return <NoMatch />;
+  }
+
   /** @todo 카드 상세 페이지 개발되면 cardRender로 링크 연결 */
-  return <BoardView board={board} />;
+  return <BoardView boardId={boardId} />;
 };
 
 export default BoardPage;

--- a/src/app/pages/BoardPage.tsx
+++ b/src/app/pages/BoardPage.tsx
@@ -4,6 +4,7 @@ import { useLocation } from 'react-router-dom';
 const BoardPage = () => {
   const location = useLocation();
   const board = location.state?.board;
+  /** @todo 카드 상세 페이지 개발되면 cardRender로 링크 연결 */
   return <BoardView board={board} />;
 };
 

--- a/src/app/pages/BoardPage.tsx
+++ b/src/app/pages/BoardPage.tsx
@@ -1,10 +1,10 @@
-import { Board } from 'kanbanwave';
+import { BoardView } from 'kanbanwave';
 import { useLocation } from 'react-router-dom';
 
 const BoardPage = () => {
   const location = useLocation();
   const board = location.state?.board;
-  return <Board board={board} />;
+  return <BoardView board={board} />;
 };
 
 export default BoardPage;

--- a/src/app/pages/BoardsPage.tsx
+++ b/src/app/pages/BoardsPage.tsx
@@ -12,6 +12,7 @@ import {
   Title
 } from 'app/components';
 import { useToggle } from 'app/hooks';
+import { Link } from 'react-router-dom';
 
 const BoardsPage = () => {
   const [open, dialogOpen] = useToggle(false);
@@ -86,7 +87,13 @@ const BoardsPage = () => {
             </DialogActions>
           </form>
         </Dialog>
-        <BoardList />
+        <BoardList
+          boardRender={provided => (
+            <Link to={`/boards/${provided.board.id}`} state={{ board: provided.board }}>
+              {provided.children}
+            </Link>
+          )}
+        />
       </div>
     </section>
   );

--- a/src/app/pages/BoardsPage.tsx
+++ b/src/app/pages/BoardsPage.tsx
@@ -89,7 +89,9 @@ const BoardsPage = () => {
         </Dialog>
         <BoardList
           boardRender={provided => (
-            <Link to={`/boards/${provided.board.id}`}>{provided.children}</Link>
+            <Link to={`/boards/${provided.meta.board.id}`}>
+              <provided.Component {...provided.props} />
+            </Link>
           )}
         />
       </div>

--- a/src/app/pages/BoardsPage.tsx
+++ b/src/app/pages/BoardsPage.tsx
@@ -1,9 +1,95 @@
-import { BoardList } from "kanbanwave"
+import { useCallback } from 'react';
+import { useForm } from 'react-hook-form';
+import { BoardList, useKanbanBoard } from 'kanbanwave';
+import {
+  Button,
+  Dialog,
+  DialogActions,
+  DialogContent,
+  DialogTitle,
+  IconButton,
+  Input,
+  Title
+} from 'app/components';
+import { useToggle } from 'app/hooks';
 
 const BoardsPage = () => {
-  return (
-    <BoardList />
-  )
-}
+  const [open, dialogOpen] = useToggle(false);
 
-export default BoardsPage
+  const boardStore = useKanbanBoard();
+
+  const {
+    register,
+    handleSubmit,
+    formState: { errors },
+    reset
+  } = useForm({
+    mode: 'onSubmit',
+    reValidateMode: 'onChange',
+    defaultValues: {
+      title: ''
+    }
+  });
+
+  const handleClose = () => {
+    dialogOpen();
+    reset();
+  };
+
+  const handleBoardSubmit = useCallback(
+    (data: { title: string }) => {
+      const { title } = data;
+      boardStore.createBoard({ title });
+      dialogOpen();
+      reset();
+    },
+    [boardStore, dialogOpen, reset]
+  );
+
+  return (
+    <section className="app-base">
+      <Title className="mb-4 text-white">Boards</Title>
+      <div className="m-9">
+        <IconButton
+          name="dashboard_customize"
+          className="mb-10 ml-2"
+          onClick={dialogOpen}>
+          Create new board
+        </IconButton>
+        <Dialog open={open} closeIcon onClose={handleClose} className="w-80">
+          <form onSubmit={handleSubmit(handleBoardSubmit)}>
+            <DialogTitle>Create board</DialogTitle>
+            <DialogContent>
+              <label htmlFor="title" className="pb-1 text-sm font-semibold label">
+                * Board title
+              </label>
+              <Input
+                id="title"
+                type="text"
+                {...register('title', {
+                  required: 'Board title is required',
+                  maxLength: {
+                    value: 100,
+                    message: 'Maximum character is 100'
+                  }
+                })}
+                placeholder="Enter a title"
+                wrapperClassName={errors.title ? 'input-bordered input-error' : ''}
+              />
+              {errors.title && (
+                <p className="pl-1 mt-1 text-xs text-red-600">{errors.title.message}</p>
+              )}
+            </DialogContent>
+            <DialogActions>
+              <Button onClick={handleClose}>Cancel</Button>
+              <Button type="submit">Confirm</Button>
+            </DialogActions>
+          </form>
+        </Dialog>
+        <BoardList />
+      </div>
+    </section>
+  );
+};
+
+export default BoardsPage;

--- a/src/app/pages/BoardsPage.tsx
+++ b/src/app/pages/BoardsPage.tsx
@@ -89,9 +89,7 @@ const BoardsPage = () => {
         </Dialog>
         <BoardList
           boardRender={provided => (
-            <Link to={`/boards/${provided.board.id}`} state={{ board: provided.board }}>
-              {provided.children}
-            </Link>
+            <Link to={`/boards/${provided.board.id}`}>{provided.children}</Link>
           )}
         />
       </div>

--- a/src/app/routes/router.tsx
+++ b/src/app/routes/router.tsx
@@ -3,13 +3,15 @@ import { NoMatch } from 'app/components/routes';
 import { BoardPage, BoardsPage } from 'app/pages';
 import { createBrowserRouter } from 'react-router-dom';
 
+export type RouterParamKeys = 'boardId';
+
 const router = createBrowserRouter([
   {
     path: '/',
     element: <BaseLayout />,
     children: [
       { path: '/boards', element: <BoardsPage /> },
-      { path: '/boards/:id', element: <BoardPage /> },
+      { path: '/boards/:boardId', element: <BoardPage /> }
     ]
   },
   { path: '*', element: <NoMatch /> }

--- a/src/kanbanwave/Board.tsx
+++ b/src/kanbanwave/Board.tsx
@@ -4,12 +4,24 @@ import { KWBoard } from './types';
 
 type BoardProps = {
   board: KWBoard;
+  /** @todo boardRender에서 onClick을 주입할 수 있도록 리팩토링 */
+  onClick?: (event: React.MouseEvent<HTMLDivElement>) => void;
   onDeleteClick?: (event: React.MouseEvent<HTMLButtonElement>) => void;
 };
 
-const Board = ({ board, onDeleteClick }: BoardProps) => {
+const Board = ({ board, onClick, onDeleteClick }: BoardProps) => {
   return (
-    <div className="p-2 transition-all rounded-lg group hover:bg-zinc-500/50">
+    <div
+      className="p-2 transition-all rounded-lg group hover:bg-zinc-500/50"
+      onClick={e => {
+        onClick?.(e);
+        if (!(e.target instanceof Element)) {
+          return;
+        }
+        if (e.target.closest('[data-event-target="delete-button"]')) {
+          e.preventDefault();
+        }
+      }}>
       <div className="flex flex-col justify-between h-full rounded-lg">
         <div className="relative flex-shrink-0">
           <img
@@ -27,6 +39,7 @@ const Board = ({ board, onDeleteClick }: BoardProps) => {
               name="delete_outlined"
               type="button"
               aria-label="delete a board"
+              data-event-target="delete-button"
               className="self-end opacity-0 btn-square group-hover:opacity-100"
               iconClassName="w-4"
               onClick={onDeleteClick}

--- a/src/kanbanwave/Board.tsx
+++ b/src/kanbanwave/Board.tsx
@@ -1,0 +1,41 @@
+import { IconButton, Subtitle } from 'app/components';
+import bgBoard from 'app/assets/bg-board.jpg';
+import { KWBoard } from './types';
+
+type BoardProps = {
+  board: KWBoard;
+  onDeleteClick?: (event: React.MouseEvent<HTMLButtonElement>) => void;
+};
+
+const Board = ({ board, onDeleteClick }: BoardProps) => {
+  return (
+    <div className="p-2 transition-all rounded-lg group hover:bg-zinc-500/50">
+      <div className="flex flex-col justify-between h-full rounded-lg">
+        <div className="relative flex-shrink-0">
+          <img
+            src={bgBoard}
+            alt="Board"
+            className="object-cover w-full h-full rounded-lg"
+          />
+          <div className="absolute flex flex-col justify-between inset-5">
+            <Subtitle
+              size="lg"
+              className="mr-1 overflow-hidden text-white text-ellipsis whitespace-nowrap">
+              {board.title}
+            </Subtitle>
+            <IconButton
+              name="delete_outlined"
+              type="button"
+              aria-label="delete a board"
+              className="self-end opacity-0 btn-square group-hover:opacity-100"
+              iconClassName="w-4"
+              onClick={onDeleteClick}
+            />
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+};
+
+export default Board;

--- a/src/kanbanwave/BoardList.tsx
+++ b/src/kanbanwave/BoardList.tsx
@@ -1,53 +1,11 @@
-import {
-  Button,
-  Dialog,
-  DialogActions,
-  DialogContent,
-  DialogTitle,
-  IconButton,
-  Input,
-  Title
-} from 'app/components';
-import { useToggle } from 'app/hooks';
 import { useCallback } from 'react';
-import { useForm } from 'react-hook-form';
 import { Link } from 'react-router-dom';
-import { useKanbanBoard } from './KanbanStorageProvider';
 import Board from './Board';
+import { useKanbanBoard } from './KanbanStorageProvider';
 
 const BoardList = () => {
-  const [open, dialogOpen] = useToggle(false);
-
   const boardStore = useKanbanBoard();
   const boards = boardStore.getBoards();
-
-  const {
-    register,
-    handleSubmit,
-    formState: { errors },
-    reset
-  } = useForm({
-    mode: 'onSubmit',
-    reValidateMode: 'onChange',
-    defaultValues: {
-      title: ''
-    }
-  });
-
-  const handleClose = () => {
-    dialogOpen();
-    reset();
-  };
-
-  const handleBoardSubmit = useCallback(
-    (data: { title: string }) => {
-      const { title } = data;
-      boardStore.createBoard({ title });
-      dialogOpen();
-      reset();
-    },
-    [boardStore, dialogOpen, reset]
-  );
 
   const handleBoardDeleteClick = useCallback(
     (boardId: string) => (e: React.MouseEvent) => {
@@ -59,59 +17,18 @@ const BoardList = () => {
   );
 
   return (
-    <section className="app-base">
-      <Title className="mb-4 text-white">Boards</Title>
-      <div className="m-9">
-        <IconButton
-          name="dashboard_customize"
-          className="mb-10 ml-2"
-          onClick={dialogOpen}>
-          Create new board
-        </IconButton>
-        <Dialog open={open} closeIcon onClose={handleClose} className="w-80">
-          <form onSubmit={handleSubmit(handleBoardSubmit)}>
-            <DialogTitle>Create board</DialogTitle>
-            <DialogContent>
-              <label htmlFor="title" className="pb-1 text-sm font-semibold label">
-                * Board title
-              </label>
-              <Input
-                id="title"
-                type="text"
-                {...register('title', {
-                  required: 'Board title is required',
-                  maxLength: {
-                    value: 100,
-                    message: 'Maximum character is 100'
-                  }
-                })}
-                placeholder="Enter a title"
-                wrapperClassName={errors.title ? 'input-bordered input-error' : ''}
-              />
-              {errors.title && (
-                <p className="pl-1 mt-1 text-xs text-red-600">{errors.title.message}</p>
-              )}
-            </DialogContent>
-            <DialogActions>
-              <Button onClick={handleClose}>Cancel</Button>
-              <Button type="submit">Confirm</Button>
-            </DialogActions>
-          </form>
-        </Dialog>
-        <ul className="flex flex-wrap gap-4">
-          {boards.map(board => (
-            <li className='w-[23%]'>
-              <Link to={`/boards/${board.id}`} state={{ board }}>
-                <Board
-                  board={board}
-                  onDeleteClick={e => handleBoardDeleteClick(board.id)(e)}
-                />
-              </Link>
-            </li>
-          ))}
-        </ul>
-      </div>
-    </section>
+    <ul className="flex flex-wrap gap-4">
+      {boards.map(board => (
+        <li className="w-[23%]">
+          <Link to={`/boards/${board.id}`} state={{ board }}>
+            <Board
+              board={board}
+              onDeleteClick={e => handleBoardDeleteClick(board.id)(e)}
+            />
+          </Link>
+        </li>
+      ))}
+    </ul>
   );
 };
 

--- a/src/kanbanwave/BoardList.tsx
+++ b/src/kanbanwave/BoardList.tsx
@@ -6,15 +6,14 @@ import {
   DialogTitle,
   IconButton,
   Input,
-  Subtitle,
   Title
 } from 'app/components';
 import { useToggle } from 'app/hooks';
 import { useCallback } from 'react';
 import { useForm } from 'react-hook-form';
 import { Link } from 'react-router-dom';
-import bgBoard from 'app/assets/bg-board.jpg';
 import { useKanbanBoard } from './KanbanStorageProvider';
+import Board from './Board';
 
 const BoardList = () => {
   const [open, dialogOpen] = useToggle(false);
@@ -50,7 +49,7 @@ const BoardList = () => {
     [boardStore, dialogOpen, reset]
   );
 
-  const handleBoardDelete = useCallback(
+  const handleBoardDeleteClick = useCallback(
     (boardId: string) => (e: React.MouseEvent) => {
       e.preventDefault();
       e.stopPropagation();
@@ -101,35 +100,12 @@ const BoardList = () => {
         </Dialog>
         <ul className="flex flex-wrap gap-4">
           {boards.map(board => (
-            <li
-              key={board.id}
-              className="w-[23%] group hover:bg-zinc-500/50 transition-all rounded-lg p-2">
-              <Link
-                to={`/boards/${board.id}`}
-                className="flex flex-col justify-between h-full rounded-lg"
-                state={{ board }}>
-                <div className="relative flex-shrink-0">
-                  <img
-                    src={bgBoard}
-                    alt="Board"
-                    className="object-cover w-full h-full rounded-lg"
-                  />
-                  <div className="absolute flex flex-col justify-between inset-5">
-                    <Subtitle
-                      size="lg"
-                      className="mr-1 overflow-hidden text-white text-ellipsis whitespace-nowrap">
-                      {board.title}
-                    </Subtitle>
-                    <IconButton
-                      name="delete_outlined"
-                      type="button"
-                      aria-label="delete a board"
-                      className="self-end opacity-0 btn-square group-hover:opacity-100"
-                      iconClassName="w-4"
-                      onClick={e => handleBoardDelete(board.id)(e)}
-                    />
-                  </div>
-                </div>
+            <li className='w-[23%]'>
+              <Link to={`/boards/${board.id}`} state={{ board }}>
+                <Board
+                  board={board}
+                  onDeleteClick={e => handleBoardDeleteClick(board.id)(e)}
+                />
               </Link>
             </li>
           ))}

--- a/src/kanbanwave/BoardList.tsx
+++ b/src/kanbanwave/BoardList.tsx
@@ -14,7 +14,7 @@ import { useCallback } from 'react';
 import { useForm } from 'react-hook-form';
 import { Link } from 'react-router-dom';
 import bgBoard from 'app/assets/bg-board.jpg';
-import { useKanbanBoard } from 'kanbanwave';
+import { useKanbanBoard } from './KanbanStorageProvider';
 
 const BoardList = () => {
   const [open, dialogOpen] = useToggle(false);

--- a/src/kanbanwave/BoardList.tsx
+++ b/src/kanbanwave/BoardList.tsx
@@ -10,9 +10,14 @@ type BoardListProps = {
     props: React.ComponentPropsWithRef<typeof Board>;
     meta: { board: KWBoard };
   }) => React.ReactNode;
+  newBoardRender?: (provided: {
+    Component: typeof NewBoard;
+    props: React.ComponentPropsWithRef<typeof NewBoard>;
+    meta: Record<PropertyKey, never>;
+  }) => React.ReactNode;
 };
 
-const BoardList = ({ boardRender }: BoardListProps) => {
+const BoardList = ({ boardRender, newBoardRender }: BoardListProps) => {
   const boardStore = useKanbanBoard();
   const boards = boardStore.getBoards();
 
@@ -52,7 +57,20 @@ const BoardList = ({ boardRender }: BoardListProps) => {
           </li>
         );
       })}
-      <NewBoard onAdd={handleBoardAdd} />
+      {(() => {
+        const newBoardProps = {
+          onAdd: handleBoardAdd
+        };
+        return newBoardRender ? (
+          newBoardRender({
+            Component: NewBoard,
+            props: newBoardProps,
+            meta: {}
+          })
+        ) : (
+          <NewBoard {...newBoardProps} />
+        );
+      })()}
     </ul>
   );
 };

--- a/src/kanbanwave/BoardList.tsx
+++ b/src/kanbanwave/BoardList.tsx
@@ -14,8 +14,6 @@ const BoardList = ({ boardRender }: BoardListProps) => {
 
   const handleBoardDeleteClick = useCallback(
     (boardId: string) => (e: React.MouseEvent) => {
-      e.preventDefault();
-      e.stopPropagation();
       boardStore.deleteBoard(boardId);
     },
     [boardStore]

--- a/src/kanbanwave/BoardList.tsx
+++ b/src/kanbanwave/BoardList.tsx
@@ -1,8 +1,8 @@
 import { useCallback } from 'react';
-import { Link } from 'react-router-dom';
 import Board from './Board';
+import NewBoard from './NewBoard';
 import { useKanbanBoard } from './KanbanStorageProvider';
-import { KWBoard } from './types';
+import { KWBoard, KWBoardForm } from './types';
 
 type BoardListProps = {
   boardRender?: (props: { board: KWBoard; children: React.ReactNode }) => React.ReactNode;
@@ -12,8 +12,16 @@ const BoardList = ({ boardRender }: BoardListProps) => {
   const boardStore = useKanbanBoard();
   const boards = boardStore.getBoards();
 
+  const handleBoardAdd = useCallback(
+    (title: string) => {
+      const board: KWBoardForm = { title };
+      boardStore.createBoard(board);
+    },
+    [boardStore]
+  );
+
   const handleBoardDeleteClick = useCallback(
-    (boardId: string) => (e: React.MouseEvent) => {
+    (boardId: string) => () => {
       boardStore.deleteBoard(boardId);
     },
     [boardStore]
@@ -23,7 +31,7 @@ const BoardList = ({ boardRender }: BoardListProps) => {
     <ul className="flex flex-wrap gap-4">
       {boards.map(board => {
         const boardNode: React.ReactNode = (
-          <Board board={board} onDeleteClick={e => handleBoardDeleteClick(board.id)(e)} />
+          <Board board={board} onDeleteClick={handleBoardDeleteClick(board.id)} />
         );
         return (
           <li className="w-[23%]">
@@ -31,6 +39,7 @@ const BoardList = ({ boardRender }: BoardListProps) => {
           </li>
         );
       })}
+      <NewBoard onAdd={handleBoardAdd} />
     </ul>
   );
 };

--- a/src/kanbanwave/BoardList.tsx
+++ b/src/kanbanwave/BoardList.tsx
@@ -5,7 +5,11 @@ import { useKanbanBoard } from './KanbanStorageProvider';
 import { KWBoard, KWBoardForm } from './types';
 
 type BoardListProps = {
-  boardRender?: (props: { board: KWBoard; children: React.ReactNode }) => React.ReactNode;
+  boardRender?: (provided: {
+    Component: typeof Board;
+    props: React.ComponentPropsWithRef<typeof Board>;
+    meta: { board: KWBoard };
+  }) => React.ReactNode;
 };
 
 const BoardList = ({ boardRender }: BoardListProps) => {
@@ -30,12 +34,21 @@ const BoardList = ({ boardRender }: BoardListProps) => {
   return (
     <ul className="flex flex-wrap gap-4">
       {boards.map(board => {
-        const boardNode: React.ReactNode = (
-          <Board board={board} onDeleteClick={handleBoardDeleteClick(board.id)} />
-        );
+        const boardProps = {
+          board: board,
+          onDeleteClick: handleBoardDeleteClick(board.id)
+        };
         return (
-          <li className="w-[23%]">
-            {boardRender ? boardRender({ board, children: boardNode }) : boardNode}
+          <li key={board.id} className="w-[23%]">
+            {boardRender ? (
+              boardRender({
+                Component: Board,
+                props: boardProps,
+                meta: { board }
+              })
+            ) : (
+              <Board {...boardProps} />
+            )}
           </li>
         );
       })}

--- a/src/kanbanwave/BoardList.tsx
+++ b/src/kanbanwave/BoardList.tsx
@@ -2,8 +2,13 @@ import { useCallback } from 'react';
 import { Link } from 'react-router-dom';
 import Board from './Board';
 import { useKanbanBoard } from './KanbanStorageProvider';
+import { KWBoard } from './types';
 
-const BoardList = () => {
+type BoardListProps = {
+  boardRender?: (props: { board: KWBoard; children: React.ReactNode }) => React.ReactNode;
+};
+
+const BoardList = ({ boardRender }: BoardListProps) => {
   const boardStore = useKanbanBoard();
   const boards = boardStore.getBoards();
 
@@ -18,16 +23,16 @@ const BoardList = () => {
 
   return (
     <ul className="flex flex-wrap gap-4">
-      {boards.map(board => (
-        <li className="w-[23%]">
-          <Link to={`/boards/${board.id}`} state={{ board }}>
-            <Board
-              board={board}
-              onDeleteClick={e => handleBoardDeleteClick(board.id)(e)}
-            />
-          </Link>
-        </li>
-      ))}
+      {boards.map(board => {
+        const boardNode: React.ReactNode = (
+          <Board board={board} onDeleteClick={e => handleBoardDeleteClick(board.id)(e)} />
+        );
+        return (
+          <li className="w-[23%]">
+            {boardRender ? boardRender({ board, children: boardNode }) : boardNode}
+          </li>
+        );
+      })}
     </ul>
   );
 };

--- a/src/kanbanwave/BoardView.tsx
+++ b/src/kanbanwave/BoardView.tsx
@@ -9,11 +9,18 @@ import ListDroppable from './ListDroppable';
 import NewCard from './NewCard';
 import CardDroppable from './CardDroppable';
 import Card from './Card';
-import { KWBoard, KWCard, KWCardForm, KWItemType, KWList, KWListForm } from './types';
+import {
+  KWBoard,
+  KWBoardUUID,
+  KWCard,
+  KWCardForm,
+  KWItemType,
+  KWList,
+  KWListForm
+} from './types';
 
 type BoardViewProps = {
-  /** @todo board 대신 boardId를 받도록 리팩토링 */
-  board: KWBoard;
+  boardId: KWBoardUUID;
   cardRender?: (props: {
     board: KWBoard;
     list: KWList;
@@ -22,10 +29,10 @@ type BoardViewProps = {
   }) => React.ReactNode;
 };
 
-const BoardView = ({ board: boardProp, cardRender }: BoardViewProps) => {
+const BoardView = ({ boardId: boardIdProp, cardRender }: BoardViewProps) => {
   const boardContentStore = useKanbanBoardContent();
 
-  const { lists, ...board } = boardContentStore.getBoardContent(boardProp.id);
+  const { lists, ...board } = boardContentStore.getBoardContent(boardIdProp);
 
   const handleListAdd = useCallback(
     (title: string) => {

--- a/src/kanbanwave/BoardView.tsx
+++ b/src/kanbanwave/BoardView.tsx
@@ -1,19 +1,19 @@
 import { Title } from 'app/components';
 import { useCallback } from 'react';
+import { DragDropContext, DropResult } from 'react-beautiful-dnd';
+import { date, dummy } from 'app/utils';
+import AddItemForm from './AddItemForm';
+import { useKanbanBoardContent } from './KanbanStorageProvider';
+import List from './List';
+import StrictModeDroppable from './StrictModeDroppable';
 import {
-  AddItemForm,
   KWBoard,
   KWCard,
   KWCardForm,
   KWItemType,
   KWListForm,
   KWListUUID,
-  List,
-  useKanbanBoardContent
-} from 'kanbanwave';
-import { DragDropContext, DropResult } from 'react-beautiful-dnd';
-import StrictModeDroppable from 'kanbanwave/StrictModeDroppable';
-import { date, dummy } from 'app/utils';
+} from './types';
 
 type BoardViewProps = {
   /** @todo board 대신 boardId를 받도록 리팩토링 */

--- a/src/kanbanwave/BoardView.tsx
+++ b/src/kanbanwave/BoardView.tsx
@@ -6,7 +6,10 @@ import NewList from './NewList';
 import { useKanbanBoardContent } from './KanbanStorageProvider';
 import List from './List';
 import ListDroppable from './ListDroppable';
-import { KWBoard, KWCard, KWCardForm, KWItemType, KWListForm, KWListUUID } from './types';
+import NewCard from './NewCard';
+import CardDroppable from './CardDroppable';
+import Card from './Card';
+import { KWBoard, KWCardForm, KWItemType, KWListForm } from './types';
 
 type BoardViewProps = {
   /** @todo board 대신 boardId를 받도록 리팩토링 */
@@ -17,11 +20,6 @@ const BoardView = ({ board: boardProp }: BoardViewProps) => {
   const boardContentStore = useKanbanBoardContent();
 
   const { lists, ...board } = boardContentStore.getBoardContent(boardProp.id);
-
-  const cardsByList = lists.reduce<Partial<Record<KWListUUID, KWCard[]>>>((acc, list) => {
-    acc[list.id] = list.cards;
-    return acc;
-  }, {});
 
   const handleListAdd = useCallback(
     (title: string) => {
@@ -58,7 +56,7 @@ const BoardView = ({ board: boardProp }: BoardViewProps) => {
   );
 
   const handleCardDelete = useCallback(
-    (listId: string) => (cardId: string) => {
+    (listId: string, cardId: string) => () => {
       boardContentStore.deleteCard(board.id, listId, cardId);
     },
     [boardContentStore, board.id]
@@ -101,11 +99,26 @@ const BoardView = ({ board: boardProp }: BoardViewProps) => {
               key={list.id}
               list={list}
               listIndex={index}
-              cards={cardsByList[list.id] ?? []}
-              onListDelete={handleListDelete(list.id)}
-              onCardAdd={handleCardAdd(list.id)}
-              onCardDelete={handleCardDelete(list.id)}
-            />
+              onDeleteClick={handleListDelete(list.id)}>
+              <CardDroppable
+                listId={list.id}
+                buttonSlot={
+                  <NewCard
+                    cardsLength={list.cards?.length}
+                    onAdd={handleCardAdd(list.id)}
+                  />
+                }
+                className="flex flex-col p-2">
+                {list.cards?.map((card, index) => (
+                  <Card
+                    key={card.id}
+                    card={card}
+                    cardIndex={index}
+                    onDeleteClick={handleCardDelete(list.id, card.id)}
+                  />
+                ))}
+              </CardDroppable>
+            </List>
           ))}
         </ListDroppable>
       </DragDropContext>

--- a/src/kanbanwave/BoardView.tsx
+++ b/src/kanbanwave/BoardView.tsx
@@ -2,18 +2,11 @@ import { Title } from 'app/components';
 import { useCallback } from 'react';
 import { DragDropContext, DropResult } from 'react-beautiful-dnd';
 import { date, dummy } from 'app/utils';
-import AddItemForm from './AddItemForm';
+import NewList from './NewList';
 import { useKanbanBoardContent } from './KanbanStorageProvider';
 import List from './List';
 import StrictModeDroppable from './StrictModeDroppable';
-import {
-  KWBoard,
-  KWCard,
-  KWCardForm,
-  KWItemType,
-  KWListForm,
-  KWListUUID,
-} from './types';
+import { KWBoard, KWCard, KWCardForm, KWItemType, KWListForm, KWListUUID } from './types';
 
 type BoardViewProps = {
   /** @todo board 대신 boardId를 받도록 리팩토링 */
@@ -120,11 +113,7 @@ const BoardView = ({ board: boardProp }: BoardViewProps) => {
                 />
               ))}
               {provided.placeholder}
-              <AddItemForm
-                itemMode="list"
-                onItemAdd={handleListAdd}
-                listsLength={lists.length}
-              />
+              <NewList onAdd={handleListAdd} listsLength={lists.length} />
             </div>
           )}
         </StrictModeDroppable>

--- a/src/kanbanwave/BoardView.tsx
+++ b/src/kanbanwave/BoardView.tsx
@@ -26,9 +26,18 @@ type BoardViewProps = {
     props: React.ComponentPropsWithRef<typeof Card>;
     meta: { board: KWBoard; list: KWList; card: KWCard };
   }) => React.ReactNode;
+  newCardRender?: (provided: {
+    Component: typeof NewCard;
+    props: React.ComponentPropsWithRef<typeof NewCard>;
+    meta: { board: KWBoard; list: KWList };
+  }) => React.ReactNode;
 };
 
-const BoardView = ({ boardId: boardIdProp, cardRender }: BoardViewProps) => {
+const BoardView = ({
+  boardId: boardIdProp,
+  cardRender,
+  newCardRender
+}: BoardViewProps) => {
   const boardContentStore = useKanbanBoardContent();
 
   const { lists, ...board } = boardContentStore.getBoardContent(boardIdProp);
@@ -114,12 +123,21 @@ const BoardView = ({ boardId: boardIdProp, cardRender }: BoardViewProps) => {
               onDeleteClick={handleListDelete(list.id)}>
               <CardDroppable
                 listId={list.id}
-                buttonSlot={
-                  <NewCard
-                    cardsLength={list.cards?.length}
-                    onAdd={handleCardAdd(list.id)}
-                  />
-                }
+                buttonSlot={(() => {
+                  const newCardProps = {
+                    cardsLength: list.cards?.length,
+                    onAdd: handleCardAdd(list.id)
+                  };
+                  return newCardRender ? (
+                    newCardRender({
+                      Component: NewCard,
+                      props: newCardProps,
+                      meta: { board, list }
+                    })
+                  ) : (
+                    <NewCard {...newCardProps} />
+                  );
+                })()}
                 className="flex flex-col p-2">
                 {list.cards?.map((card, index) => {
                   const cardProps = {

--- a/src/kanbanwave/BoardView.tsx
+++ b/src/kanbanwave/BoardView.tsx
@@ -9,14 +9,20 @@ import ListDroppable from './ListDroppable';
 import NewCard from './NewCard';
 import CardDroppable from './CardDroppable';
 import Card from './Card';
-import { KWBoard, KWCardForm, KWItemType, KWListForm } from './types';
+import { KWBoard, KWCard, KWCardForm, KWItemType, KWList, KWListForm } from './types';
 
 type BoardViewProps = {
   /** @todo board 대신 boardId를 받도록 리팩토링 */
   board: KWBoard;
+  cardRender?: (props: {
+    board: KWBoard;
+    list: KWList;
+    card: KWCard;
+    children: React.ReactNode;
+  }) => React.ReactNode;
 };
 
-const BoardView = ({ board: boardProp }: BoardViewProps) => {
+const BoardView = ({ board: boardProp, cardRender }: BoardViewProps) => {
   const boardContentStore = useKanbanBoardContent();
 
   const { lists, ...board } = boardContentStore.getBoardContent(boardProp.id);
@@ -109,14 +115,19 @@ const BoardView = ({ board: boardProp }: BoardViewProps) => {
                   />
                 }
                 className="flex flex-col p-2">
-                {list.cards?.map((card, index) => (
-                  <Card
-                    key={card.id}
-                    card={card}
-                    cardIndex={index}
-                    onDeleteClick={handleCardDelete(list.id, card.id)}
-                  />
-                ))}
+                {list.cards?.map((card, index) => {
+                  const cardNode: React.ReactNode = (
+                    <Card
+                      key={card.id}
+                      card={card}
+                      cardIndex={index}
+                      onDeleteClick={handleCardDelete(list.id, card.id)}
+                    />
+                  );
+                  return cardRender
+                    ? cardRender({ board, list, card, children: cardNode })
+                    : cardNode;
+                })}
               </CardDroppable>
             </List>
           ))}

--- a/src/kanbanwave/BoardView.tsx
+++ b/src/kanbanwave/BoardView.tsx
@@ -5,7 +5,7 @@ import { date, dummy } from 'app/utils';
 import NewList from './NewList';
 import { useKanbanBoardContent } from './KanbanStorageProvider';
 import List from './List';
-import StrictModeDroppable from './StrictModeDroppable';
+import ListDroppable from './ListDroppable';
 import { KWBoard, KWCard, KWCardForm, KWItemType, KWListForm, KWListUUID } from './types';
 
 type BoardViewProps = {
@@ -92,31 +92,22 @@ const BoardView = ({ board: boardProp }: BoardViewProps) => {
     <section className="app-base">
       <Title className="mb-4 text-white">{board.title}</Title>
       <DragDropContext onDragEnd={handleDragEnd}>
-        <StrictModeDroppable
-          droppableId={board.id}
-          direction="horizontal"
-          type={KWItemType.LIST}>
-          {provided => (
-            <div
-              ref={provided.innerRef}
-              {...provided.droppableProps}
-              className="flex justify-start">
-              {lists.map((list, index) => (
-                <List
-                  key={list.id}
-                  list={list}
-                  cards={cardsByList[list.id] ?? []}
-                  index={index}
-                  onListDelete={handleListDelete(list.id)}
-                  onCardAdd={handleCardAdd(list.id)}
-                  onCardDelete={handleCardDelete(list.id)}
-                />
-              ))}
-              {provided.placeholder}
-              <NewList onAdd={handleListAdd} listsLength={lists.length} />
-            </div>
-          )}
-        </StrictModeDroppable>
+        <ListDroppable
+          boardId={board.id}
+          buttonSlot={<NewList onAdd={handleListAdd} listsLength={lists.length} />}
+          className="flex justify-start">
+          {lists.map((list, index) => (
+            <List
+              key={list.id}
+              list={list}
+              listIndex={index}
+              cards={cardsByList[list.id] ?? []}
+              onListDelete={handleListDelete(list.id)}
+              onCardAdd={handleCardAdd(list.id)}
+              onCardDelete={handleCardDelete(list.id)}
+            />
+          ))}
+        </ListDroppable>
       </DragDropContext>
     </section>
   );

--- a/src/kanbanwave/BoardView.tsx
+++ b/src/kanbanwave/BoardView.tsx
@@ -15,12 +15,12 @@ import { DragDropContext, DropResult } from 'react-beautiful-dnd';
 import StrictModeDroppable from 'kanbanwave/StrictModeDroppable';
 import { date, dummy } from 'app/utils';
 
-type BoardProps = {
+type BoardViewProps = {
   /** @todo board 대신 boardId를 받도록 리팩토링 */
   board: KWBoard;
 };
 
-const Board = ({ board: boardProp }: BoardProps) => {
+const BoardView = ({ board: boardProp }: BoardViewProps) => {
   const boardContentStore = useKanbanBoardContent();
 
   const { lists, ...board } = boardContentStore.getBoardContent(boardProp.id);
@@ -133,4 +133,4 @@ const Board = ({ board: boardProp }: BoardProps) => {
   );
 };
 
-export default Board;
+export default BoardView;

--- a/src/kanbanwave/BoardView.tsx
+++ b/src/kanbanwave/BoardView.tsx
@@ -1,5 +1,5 @@
 import { Title } from 'app/components';
-import { useCallback } from 'react';
+import { Fragment, useCallback } from 'react';
 import { DragDropContext, DropResult } from 'react-beautiful-dnd';
 import { date, dummy } from 'app/utils';
 import NewList from './NewList';
@@ -21,11 +21,10 @@ import {
 
 type BoardViewProps = {
   boardId: KWBoardUUID;
-  cardRender?: (props: {
-    board: KWBoard;
-    list: KWList;
-    card: KWCard;
-    children: React.ReactNode;
+  cardRender?: (provided: {
+    Component: typeof Card;
+    props: React.ComponentPropsWithRef<typeof Card>;
+    meta: { board: KWBoard; list: KWList; card: KWCard };
   }) => React.ReactNode;
 };
 
@@ -123,17 +122,24 @@ const BoardView = ({ boardId: boardIdProp, cardRender }: BoardViewProps) => {
                 }
                 className="flex flex-col p-2">
                 {list.cards?.map((card, index) => {
-                  const cardNode: React.ReactNode = (
-                    <Card
-                      key={card.id}
-                      card={card}
-                      cardIndex={index}
-                      onDeleteClick={handleCardDelete(list.id, card.id)}
-                    />
+                  const cardProps = {
+                    card: card,
+                    cardIndex: index,
+                    onDeleteClick: handleCardDelete(list.id, card.id)
+                  };
+                  return (
+                    <Fragment key={`${list.id}:${card.id}`}>
+                      {cardRender ? (
+                        cardRender({
+                          Component: Card,
+                          props: cardProps,
+                          meta: { board, list, card }
+                        })
+                      ) : (
+                        <Card {...cardProps} />
+                      )}
+                    </Fragment>
                   );
-                  return cardRender
-                    ? cardRender({ board, list, card, children: cardNode })
-                    : cardNode;
                 })}
               </CardDroppable>
             </List>

--- a/src/kanbanwave/Card.tsx
+++ b/src/kanbanwave/Card.tsx
@@ -6,6 +6,7 @@ import CardDraggable from './CardDraggable';
 type CardProps = {
   card: KWCard;
   cardIndex: number;
+  /** @todo cardRender에서 onClick을 주입할 수 있도록 리팩토링 */
   onClick?: (event: React.MouseEvent<HTMLDivElement>) => void;
   onEditClick?: (event: React.MouseEvent<HTMLButtonElement>) => void;
   onDeleteClick?: (event: React.MouseEvent<HTMLButtonElement>) => void;
@@ -19,23 +20,38 @@ const Card = ({ card, cardIndex, onClick, onEditClick, onDeleteClick }: CardProp
 
   return (
     <CardDraggable cardId={card.id} cardIndex={cardIndex}>
-      <div className="card group" onClick={onClick}>
+      <div
+        className="card group"
+        onClick={e => {
+          onClick?.(e);
+          if (!(e.target instanceof Element)) {
+            return;
+          }
+          if (e.target.closest('[data-event-target="menu-button"]')) {
+            e.preventDefault();
+          }
+        }}>
         <div className="relative flex items-center justify-between overflow-hidden break-words whitespace-normal">
           <div className="w-[calc(100%-32px)]">{card.title}</div>
           <IconButton
             name="edit"
             className="single-icon group-hover:flex"
             onClick={handleMenuOpen}
+            data-event-target="menu-button"
           />
         </div>
       </div>
       {open && (
         <ul className="flex flex-row justify-around mb-1 menu menu-vertical lg:menu-horizontal bg-base-200 rounded-box">
           <li>
-            <button type="button" onClick={onEditClick}>Edit card</button>
+            <button type="button" onClick={onEditClick}>
+              Edit card
+            </button>
           </li>
           <li>
-            <button type="button" onClick={onDeleteClick}>Delete card</button>
+            <button type="button" onClick={onDeleteClick}>
+              Delete card
+            </button>
           </li>
         </ul>
       )}

--- a/src/kanbanwave/Card.tsx
+++ b/src/kanbanwave/Card.tsx
@@ -6,18 +6,12 @@ import CardDraggable from './CardDraggable';
 type CardProps = {
   card: KWCard;
   cardIndex: number;
-  onCardClick?: () => void;
-  onCardEdit?: () => void;
-  onCardDelete?: () => void;
+  onClick?: (event: React.MouseEvent<HTMLDivElement>) => void;
+  onEditClick?: (event: React.MouseEvent<HTMLButtonElement>) => void;
+  onDeleteClick?: (event: React.MouseEvent<HTMLButtonElement>) => void;
 };
 
-const Card = ({
-  card,
-  cardIndex,
-  onCardClick,
-  onCardEdit,
-  onCardDelete
-}: CardProps) => {
+const Card = ({ card, cardIndex, onClick, onEditClick, onDeleteClick }: CardProps) => {
   const [open, menuOpen] = useToggle(false);
   const handleMenuOpen = () => {
     menuOpen();
@@ -25,7 +19,7 @@ const Card = ({
 
   return (
     <CardDraggable cardId={card.id} cardIndex={cardIndex}>
-      <div className="card group" onClick={onCardClick}>
+      <div className="card group" onClick={onClick}>
         {/* @todo 카드 상세 페이지 개발되면, 링크 연결 */}
         <a className="relative flex items-center justify-between overflow-hidden break-words whitespace-normal">
           <div className="w-[calc(100%-32px)]">{card.title}</div>
@@ -38,11 +32,11 @@ const Card = ({
       </div>
       {open && (
         <ul className="flex flex-row justify-around mb-1 menu menu-vertical lg:menu-horizontal bg-base-200 rounded-box">
-          <li onClick={onCardEdit}>
-            <a>Edit card</a>
+          <li>
+            <button type="button" onClick={onEditClick}>Edit card</button>
           </li>
-          <li onClick={onCardDelete}>
-            <a>Delete card</a>
+          <li>
+            <button type="button" onClick={onDeleteClick}>Delete card</button>
           </li>
         </ul>
       )}

--- a/src/kanbanwave/Card.tsx
+++ b/src/kanbanwave/Card.tsx
@@ -5,8 +5,7 @@ import CardDraggable from './CardDraggable';
 
 type CardProps = {
   card: KWCard;
-  draggableId: string;
-  index: number;
+  cardIndex: number;
   onCardClick?: () => void;
   onCardEdit?: () => void;
   onCardDelete?: () => void;
@@ -14,8 +13,7 @@ type CardProps = {
 
 const Card = ({
   card,
-  draggableId,
-  index,
+  cardIndex,
   onCardClick,
   onCardEdit,
   onCardDelete
@@ -26,7 +24,7 @@ const Card = ({
   };
 
   return (
-    <CardDraggable draggableId={draggableId} index={index}>
+    <CardDraggable cardId={card.id} cardIndex={cardIndex}>
       <div className="card group" onClick={onCardClick}>
         {/* @todo 카드 상세 페이지 개발되면, 링크 연결 */}
         <a className="relative flex items-center justify-between overflow-hidden break-words whitespace-normal">

--- a/src/kanbanwave/Card.tsx
+++ b/src/kanbanwave/Card.tsx
@@ -20,15 +20,14 @@ const Card = ({ card, cardIndex, onClick, onEditClick, onDeleteClick }: CardProp
   return (
     <CardDraggable cardId={card.id} cardIndex={cardIndex}>
       <div className="card group" onClick={onClick}>
-        {/* @todo 카드 상세 페이지 개발되면, 링크 연결 */}
-        <a className="relative flex items-center justify-between overflow-hidden break-words whitespace-normal">
+        <div className="relative flex items-center justify-between overflow-hidden break-words whitespace-normal">
           <div className="w-[calc(100%-32px)]">{card.title}</div>
           <IconButton
             name="edit"
             className="single-icon group-hover:flex"
             onClick={handleMenuOpen}
           />
-        </a>
+        </div>
       </div>
       {open && (
         <ul className="flex flex-row justify-around mb-1 menu menu-vertical lg:menu-horizontal bg-base-200 rounded-box">

--- a/src/kanbanwave/CardDraggable.tsx
+++ b/src/kanbanwave/CardDraggable.tsx
@@ -1,27 +1,33 @@
 import { ReactNode } from 'react';
 import { Draggable } from 'react-beautiful-dnd';
 
-type CardDraggableProps = {
+type CardDraggableProps = React.ComponentPropsWithoutRef<'div'> & {
   children: ReactNode;
   draggableId: string; // 카드의 uuid
   index: number; // 카드가 담긴 배열에서의 특정 위치
 };
 
-const CardDraggable = ({ children, draggableId, index }: CardDraggableProps) => {
+const CardDraggable: React.FC<CardDraggableProps> = ({
+  children,
+  draggableId,
+  index,
+  ...restProps
+}) => {
   return (
     <Draggable draggableId={draggableId} index={index}>
-      {provided => {
-        return (
-          <div
-            {...provided.draggableProps}
-            ref={provided.innerRef}
-            {...provided.dragHandleProps}>
-            {children}
-          </div>
-        );
-      }}
+      {provided => (
+        <div
+          {...provided.draggableProps}
+          ref={provided.innerRef}
+          {...provided.dragHandleProps}
+          {...restProps}>
+          {children}
+        </div>
+      )}
     </Draggable>
   );
 };
+
+CardDraggable.displayName = 'CardDraggable';
 
 export default CardDraggable;

--- a/src/kanbanwave/CardDroppable.tsx
+++ b/src/kanbanwave/CardDroppable.tsx
@@ -2,27 +2,28 @@ import { ReactNode } from 'react';
 import { KWItemType } from './types';
 import StrictModeDroppable from './StrictModeDroppable';
 
-type CardDroppableProps = {
+type CardDroppableProps = React.ComponentPropsWithoutRef<'div'> & {
   children: ReactNode;
   droppableId: string;
 };
 
-const CardDroppable = ({ children, droppableId }: CardDroppableProps) => {
+const CardDroppable: React.FC<CardDroppableProps> = ({
+  children,
+  droppableId,
+  ...restProps
+}) => {
   return (
     <StrictModeDroppable droppableId={droppableId} type={KWItemType.CARD}>
-      {provided => {
-        return (
-          <div
-            {...provided.droppableProps}
-            ref={provided.innerRef}
-            className="flex flex-col p-2">
-            {children}
-            {provided.placeholder}
-          </div>
-        );
-      }}
+      {provided => (
+        <div {...provided.droppableProps} ref={provided.innerRef} {...restProps}>
+          {children}
+          {provided.placeholder}
+        </div>
+      )}
     </StrictModeDroppable>
   );
 };
+
+CardDroppable.displayName = 'CardDroppable';
 
 export default CardDroppable;

--- a/src/kanbanwave/List.tsx
+++ b/src/kanbanwave/List.tsx
@@ -1,30 +1,15 @@
-import NewCard from './NewCard';
 import { KWCard, KWList } from './types';
 import { IconButton, Subtitle } from 'app/components';
-import CardDroppable from './CardDroppable';
-import Card from './Card';
 import ListDraggable from './ListDraggable';
 
 type ListProps = {
+  children?: React.ReactNode;
   list: KWList;
   listIndex: number;
-  cards: KWCard[];
-  onListMove?: (dragIndex: number, hoverIndex: number) => void;
-  onListDelete?: () => void;
-  onCardAdd?: (title: string) => void;
-  onCardDelete?: (cardId: string) => void;
+  onDeleteClick?: (event: React.MouseEvent<HTMLButtonElement>) => void;
 };
 
-const List = ({
-  list,
-  listIndex,
-  cards,
-  onListMove,
-  onListDelete,
-  onCardAdd,
-  onCardDelete,
-  ...props
-}: ListProps) => {
+const List = ({ children, list, listIndex, onDeleteClick, ...props }: ListProps) => {
   return (
     <ListDraggable listId={list.id} listIndex={listIndex}>
       <div {...props} className="w-64 p-2 mr-2 bg-white rounded-lg shadow-lg h-fit">
@@ -37,23 +22,11 @@ const List = ({
               name="remove"
               className="single-icon"
               aria-label="delete a list"
-              onClick={onListDelete}
+              onClick={onDeleteClick}
             />
           </div>
         </div>
-        <CardDroppable
-          listId={list.id}
-          buttonSlot={<NewCard onAdd={onCardAdd} cardsLength={cards?.length} />}
-          className="flex flex-col p-2">
-          {cards?.map((card, index) => (
-            <Card
-              key={card.id}
-              card={card}
-              cardIndex={index}
-              onCardDelete={() => onCardDelete?.(card.id)}
-            />
-          ))}
-        </CardDroppable>
+        {children}
       </div>
     </ListDraggable>
   );

--- a/src/kanbanwave/List.tsx
+++ b/src/kanbanwave/List.tsx
@@ -1,4 +1,4 @@
-import AddItemForm from './AddItemForm';
+import NewCard from './NewCard';
 import { KWCard, KWList } from './types';
 import { IconButton, Subtitle } from 'app/components';
 import { Draggable } from 'react-beautiful-dnd';
@@ -58,11 +58,7 @@ const List = ({
               />
             ))}
           </CardDroppable>
-          <AddItemForm
-            itemMode="card"
-            onItemAdd={onCardAdd}
-            listsLength={cards?.length}
-          />
+          <NewCard onAdd={onCardAdd} cardsLength={cards?.length} />
         </div>
       )}
     </Draggable>

--- a/src/kanbanwave/List.tsx
+++ b/src/kanbanwave/List.tsx
@@ -47,7 +47,7 @@ const List = ({
               />
             </div>
           </div>
-          <CardDroppable droppableId={list.id}>
+          <CardDroppable droppableId={list.id} className="flex flex-col p-2">
             {cards?.map((card, index) => (
               <Card
                 key={card.id}

--- a/src/kanbanwave/List.tsx
+++ b/src/kanbanwave/List.tsx
@@ -1,13 +1,13 @@
 import NewCard from './NewCard';
 import { KWCard, KWList } from './types';
 import { IconButton, Subtitle } from 'app/components';
-import { Draggable } from 'react-beautiful-dnd';
 import CardDroppable from './CardDroppable';
 import Card from './Card';
+import ListDraggable from './ListDraggable';
 
 type ListProps = {
-  index: number;
   list: KWList;
+  listIndex: number;
   cards: KWCard[];
   onListMove?: (dragIndex: number, hoverIndex: number) => void;
   onListDelete?: () => void;
@@ -16,8 +16,8 @@ type ListProps = {
 };
 
 const List = ({
-  index,
   list,
+  listIndex,
   cards,
   onListMove,
   onListDelete,
@@ -26,42 +26,36 @@ const List = ({
   ...props
 }: ListProps) => {
   return (
-    <Draggable draggableId={list.id} index={index}>
-      {provided => (
-        <div
-          {...provided.draggableProps}
-          ref={provided.innerRef}
-          {...provided.dragHandleProps}
-          {...props}
-          className="w-64 p-2 mr-2 bg-white rounded-lg shadow-lg h-fit">
-          <div className="flex items-center justify-between mb-2">
-            <Subtitle className="flex-1 pl-2 break-all" size="lg">
-              {list.title}
-            </Subtitle>
-            <div className="flex justify-between ml-2">
-              <IconButton
-                name="remove"
-                className="single-icon"
-                aria-label="delete a list"
-                onClick={onListDelete}
-              />
-            </div>
+    <ListDraggable listId={list.id} listIndex={listIndex}>
+      <div {...props} className="w-64 p-2 mr-2 bg-white rounded-lg shadow-lg h-fit">
+        <div className="flex items-center justify-between mb-2">
+          <Subtitle className="flex-1 pl-2 break-all" size="lg">
+            {list.title}
+          </Subtitle>
+          <div className="flex justify-between ml-2">
+            <IconButton
+              name="remove"
+              className="single-icon"
+              aria-label="delete a list"
+              onClick={onListDelete}
+            />
           </div>
-          <CardDroppable droppableId={list.id} className="flex flex-col p-2">
-            {cards?.map((card, index) => (
-              <Card
-                key={card.id}
-                card={card}
-                onCardDelete={() => onCardDelete?.(card.id)}
-                draggableId={card.id}
-                index={index}
-              />
-            ))}
-          </CardDroppable>
-          <NewCard onAdd={onCardAdd} cardsLength={cards?.length} />
         </div>
-      )}
-    </Draggable>
+        <CardDroppable
+          listId={list.id}
+          buttonSlot={<NewCard onAdd={onCardAdd} cardsLength={cards?.length} />}
+          className="flex flex-col p-2">
+          {cards?.map((card, index) => (
+            <Card
+              key={card.id}
+              card={card}
+              cardIndex={index}
+              onCardDelete={() => onCardDelete?.(card.id)}
+            />
+          ))}
+        </CardDroppable>
+      </div>
+    </ListDraggable>
   );
 };
 

--- a/src/kanbanwave/ListDraggable.tsx
+++ b/src/kanbanwave/ListDraggable.tsx
@@ -1,18 +1,18 @@
 import { Draggable } from 'react-beautiful-dnd';
 
-type CardDraggableProps = React.ComponentPropsWithoutRef<'div'> & {
-  cardId: string;
-  cardIndex: number;
+type ListDraggableProps = React.ComponentPropsWithoutRef<'div'> & {
+  listId: string;
+  listIndex: number;
 };
 
-const CardDraggable: React.FC<CardDraggableProps> = ({
+const ListDraggable: React.FC<ListDraggableProps> = ({
   children,
-  cardId,
-  cardIndex,
+  listId,
+  listIndex,
   ...restProps
 }) => {
   return (
-    <Draggable draggableId={cardId} index={cardIndex}>
+    <Draggable draggableId={listId} index={listIndex}>
       {provided => (
         <div
           {...provided.draggableProps}
@@ -26,6 +26,6 @@ const CardDraggable: React.FC<CardDraggableProps> = ({
   );
 };
 
-CardDraggable.displayName = 'CardDraggable';
+ListDraggable.displayName = 'ListDraggable';
 
-export default CardDraggable;
+export default ListDraggable;

--- a/src/kanbanwave/ListDroppable.tsx
+++ b/src/kanbanwave/ListDroppable.tsx
@@ -1,19 +1,23 @@
 import { KWItemType } from './types';
 import StrictModeDroppable from './StrictModeDroppable';
+import React from 'react';
 
-type CardDroppableProps = React.ComponentPropsWithoutRef<'div'> & {
+type ListDroppableProps = React.ComponentPropsWithoutRef<'div'> & {
   buttonSlot?: React.ReactNode;
-  listId: string;
+  boardId: string;
 };
 
-const CardDroppable: React.FC<CardDroppableProps> = ({
+const ListDroppable: React.FC<ListDroppableProps> = ({
   children,
   buttonSlot,
-  listId,
+  boardId,
   ...restProps
 }) => {
   return (
-    <StrictModeDroppable droppableId={listId} type={KWItemType.CARD}>
+    <StrictModeDroppable
+      droppableId={boardId}
+      type={KWItemType.LIST}
+      direction="horizontal">
       {provided => (
         <div {...provided.droppableProps} ref={provided.innerRef} {...restProps}>
           {children}
@@ -25,6 +29,6 @@ const CardDroppable: React.FC<CardDroppableProps> = ({
   );
 };
 
-CardDroppable.displayName = 'CardDroppable';
+ListDroppable.displayName = 'ListDroppable';
 
-export default CardDroppable;
+export default ListDroppable;

--- a/src/kanbanwave/NewBoard.tsx
+++ b/src/kanbanwave/NewBoard.tsx
@@ -1,0 +1,67 @@
+import { ChangeEvent, useCallback, useState } from 'react';
+import { Button, IconButton, TextArea } from 'app/components';
+import clsx from 'clsx';
+
+type NewBoardProps = {
+  className?: string;
+  onAdd?: (title: string) => void;
+};
+
+const NewBoard = ({ className, onAdd }: NewBoardProps) => {
+  const [isInputVisible, setIsInputVisible] = useState(false);
+  const [title, setTitle] = useState('');
+
+  const handleChange = useCallback((e: ChangeEvent<HTMLTextAreaElement>) => {
+    setTitle(e.target.value);
+  }, []);
+
+  const handleClick = useCallback(() => {
+    if (title.trim() !== '') {
+      onAdd?.(title);
+      setIsInputVisible(false);
+      setTitle('');
+    }
+  }, [title, onAdd]);
+
+  const handleCancel = () => {
+    setIsInputVisible(false);
+    setTitle('');
+  };
+
+  return (
+    <div className="h-[272px] rounded-lg w-[23%] bg-zinc-50 shrink-0">
+      {isInputVisible ? (
+        <div className={clsx('p-2', className)}>
+          <TextArea
+            placeholder={`Enter a board title`}
+            value={title}
+            onChange={handleChange}
+            className="w-full py-1 leading-8 min-h-11 "
+          />
+          <div className="flex items-start mt-1">
+            <Button type="button" className="mr-2" onClick={handleClick}>
+              Add board
+            </Button>
+            <IconButton
+              name="close"
+              type="button"
+              aria-label="cancel"
+              onClick={handleCancel}
+              className="btn-square"
+            />
+          </div>
+        </div>
+      ) : (
+        <IconButton
+          name="add"
+          aria-label={`add a board`}
+          onClick={() => setIsInputVisible(true)}
+          className={clsx('w-full h-full')}>
+          <span className="text-sm">Add another board</span>
+        </IconButton>
+      )}
+    </div>
+  );
+};
+
+export default NewBoard;

--- a/src/kanbanwave/NewCard.tsx
+++ b/src/kanbanwave/NewCard.tsx
@@ -1,0 +1,79 @@
+import { ChangeEvent, useCallback, useEffect, useState } from 'react';
+import { Button, IconButton, TextArea } from 'app/components';
+import clsx from 'clsx';
+
+type NewCardProps = {
+  className?: string;
+  cardsLength?: number;
+  onAdd?: (title: string) => void;
+};
+
+const NewCard = ({ className, cardsLength, onAdd }: NewCardProps) => {
+  const [isInputVisible, setIsInputVisible] = useState(false);
+  const [title, setTitle] = useState('');
+
+  const handleChange = useCallback((e: ChangeEvent<HTMLTextAreaElement>) => {
+    setTitle(e.target.value);
+  }, []);
+
+  const handleClick = useCallback(
+    (e: React.MouseEvent<HTMLButtonElement>) => {
+      e.preventDefault();
+      if (title.trim() !== '') {
+        onAdd?.(title);
+        setTitle('');
+      }
+    },
+    [title, onAdd]
+  );
+
+  const handleCancel = () => {
+    setTitle('');
+    setIsInputVisible(false);
+  };
+
+  useEffect(() => {
+    if (cardsLength === 0) {
+      setIsInputVisible(true);
+    } else {
+      setIsInputVisible(false);
+    }
+  }, [cardsLength]);
+
+  return (
+    <div className="flex flex-col w-full rounded-lg max-w-64 bg-zinc-50 shrink-0 h-fit">
+      {isInputVisible ? (
+        <div className={clsx('p-2', className)}>
+          <TextArea
+            placeholder={`Enter a card title`}
+            value={title}
+            onChange={handleChange}
+            className="w-full py-1 leading-8 min-h-11 "
+          />
+          <div className="flex items-start mt-1">
+            <Button type="button" className="mr-2" onClick={handleClick}>
+              Add card
+            </Button>
+            <IconButton
+              name="close"
+              type="button"
+              aria-label="cancel"
+              onClick={handleCancel}
+              className="btn-square"
+            />
+          </div>
+        </div>
+      ) : (
+        <IconButton
+          name="add"
+          aria-label={`add a card`}
+          onClick={() => setIsInputVisible(true)}
+          className={clsx('h-11', 'mt-1')}>
+          <span className="text-sm">Add a card</span>
+        </IconButton>
+      )}
+    </div>
+  );
+};
+
+export default NewCard;

--- a/src/kanbanwave/NewList.tsx
+++ b/src/kanbanwave/NewList.tsx
@@ -1,21 +1,14 @@
 import { ChangeEvent, useCallback, useEffect, useState } from 'react';
 import { Button, IconButton, TextArea } from 'app/components';
 import clsx from 'clsx';
-import { KWItemType } from './types';
 
-type AddItemFormProps = {
+type NewListProps = {
   className?: string;
-  itemMode: KWItemType;
   listsLength?: number;
-  onItemAdd?: (title: string) => void;
+  onAdd?: (title: string) => void;
 };
 
-const AddItemForm = ({
-  className,
-  itemMode,
-  listsLength,
-  onItemAdd
-}: AddItemFormProps) => {
+const NewList = ({ className, listsLength, onAdd }: NewListProps) => {
   const [isInputVisible, setIsInputVisible] = useState(false);
   const [title, setTitle] = useState('');
 
@@ -27,11 +20,11 @@ const AddItemForm = ({
     (e: React.MouseEvent<HTMLButtonElement>) => {
       e.preventDefault();
       if (title.trim() !== '') {
-        onItemAdd?.(title);
+        onAdd?.(title);
         setTitle('');
       }
     },
-    [title, onItemAdd]
+    [title, onAdd]
   );
 
   const handleCancel = () => {
@@ -52,16 +45,14 @@ const AddItemForm = ({
       {isInputVisible ? (
         <div className={clsx('p-2', className)}>
           <TextArea
-            placeholder={`Enter a ${
-              itemMode === KWItemType.CARD ? 'card' : 'list'
-            } title`}
+            placeholder={`Enter a list title`}
             value={title}
             onChange={handleChange}
             className="w-full py-1 leading-8 min-h-11 "
           />
           <div className="flex items-start mt-1">
             <Button type="button" className="mr-2" onClick={handleClick}>
-              Add {itemMode}
+              Add list
             </Button>
             <IconButton
               name="close"
@@ -75,18 +66,14 @@ const AddItemForm = ({
       ) : (
         <IconButton
           name="add"
-          aria-label={`add a ${itemMode}`}
+          aria-label={`add a list`}
           onClick={() => setIsInputVisible(true)}
-          className={clsx('h-11', {
-            'mt-1': itemMode === KWItemType.CARD
-          })}>
-          <span className="text-sm">
-            {itemMode === KWItemType.CARD ? 'Add a card' : 'Add another list'}
-          </span>
+          className={clsx('h-11')}>
+          <span className="text-sm">Add another list</span>
         </IconButton>
       )}
     </div>
   );
 };
 
-export default AddItemForm;
+export default NewList;

--- a/src/kanbanwave/StrictModeDroppable.tsx
+++ b/src/kanbanwave/StrictModeDroppable.tsx
@@ -1,7 +1,10 @@
-import { useEffect, useState } from 'react';
-import { Droppable, DroppableProps } from 'react-beautiful-dnd';
+import { forwardRef, useEffect, useState } from 'react';
+import { Droppable } from 'react-beautiful-dnd';
 
-const StrictModeDroppable = ({ children, ...props }: DroppableProps) => {
+const StrictModeDroppable = forwardRef<
+  React.ComponentRef<typeof Droppable>,
+  React.ComponentPropsWithoutRef<typeof Droppable>
+>((props, ref) => {
   const [enabled, setEnabled] = useState(false);
 
   useEffect(() => {
@@ -17,7 +20,9 @@ const StrictModeDroppable = ({ children, ...props }: DroppableProps) => {
     return null;
   }
 
-  return <Droppable {...props}>{children}</Droppable>;
-};
+  return <Droppable ref={ref} {...props} />;
+});
+
+StrictModeDroppable.displayName = 'StrictModeDroppable';
 
 export default StrictModeDroppable;

--- a/src/kanbanwave/index.ts
+++ b/src/kanbanwave/index.ts
@@ -8,7 +8,6 @@ export {
   type KanbanStorageContextValue
 } from './KanbanStorageProvider';
 
-export { default as AddItemForm } from './AddItemForm'
 export { default as BoardList } from './BoardList'
 export { default as BoardView } from './BoardView'
 export { default as Card } from './Card'

--- a/src/kanbanwave/index.ts
+++ b/src/kanbanwave/index.ts
@@ -9,7 +9,7 @@ export {
 } from './KanbanStorageProvider';
 
 export { default as AddItemForm } from './AddItemForm'
-export { default as Board } from './Board'
 export { default as BoardList } from './BoardList'
+export { default as BoardView } from './BoardView'
 export { default as Card } from './Card'
 export { default as List } from './List'

--- a/src/kanbanwave/index.ts
+++ b/src/kanbanwave/index.ts
@@ -8,6 +8,7 @@ export {
   type KanbanStorageContextValue
 } from './KanbanStorageProvider';
 
+export { default as Board } from './Board'
 export { default as BoardList } from './BoardList'
 export { default as BoardView } from './BoardView'
 export { default as Card } from './Card'


### PR DESCRIPTION
## Description
- Rename component `Board` to `BoardView`.
- Extract `Board` component.
- Separate `AddItemForm` into `NewList` and `NewCard`.
- Delegate page-related logic from `BoardList` to `BoardsPage`.
- Add boardRender, cardRender props.
- Remove stopPropagation nested button click event.
- Change router to manage boardId instead of board state.
- Add `NewBoard`.
- Fix value prop to `TextArea` component.
- Improve render prop specs.
- Add render props for new item.
- Fix import path.
- Separate `AddItemForm` into `NewList` and `NewCard`.

- Change prop types related to DnD.
- Add `ListDraggable`, `ListDroppable` components.

## What type of PR is this?
- [ ] 🐛 Bug fix
- [ ] 🍕 Feature
- [X] 🎨 Code style update (formatting, local variables)
- [X] ⚡️ Refactoring (no functional changes, no api changes)
- [ ] 🧹 Chore (non-breaking change which does not affect codebase; Build related changes, version modification, etc.)
- [ ] 🔁 CI related changes
- [ ] 🧪 Test Case
- [ ] 🔥 Performance optimization
- [ ] 📄 Site/documentation update
- [ ] 🤷🏻‍♀️ Other... Please describe:


## Changes made
`BoardCollection` 컴포넌트는 `boardRender`, `newBoardRender` 두 가지 콜백 함수를 받는다. 각각의 보드와 새로운 보드를 커스터마이징하여 렌더링할 수 있다.
`BoardView` 컴포넌트 또한 `cardRender`, `newCardRender` 두 가지 콜백 함수를 받는다. 각각의 카드와 새로운 카드를 커스터마이징하여 렌더링할 수 있다.