### PR TITLE
Refactor/store api

### DIFF
--- a/src/app/components/layout/Nav.tsx
+++ b/src/app/components/layout/Nav.tsx
@@ -10,14 +10,14 @@ type NavProps = {
 };
 
 const Nav = ({ open, onClickDrawer }: NavProps) => {
-  const kanbanwaveStore = useKanbanwaveStore();
+  const { getBoards } = useKanbanwaveStore();
   const [boards, setBoards] = useState<KWBoard[]>([]);
 
   useEffect(() => {
     (async () => {
-      setBoards(await kanbanwaveStore.getBoards());
+      setBoards(await getBoards());
     })();
-  }, [kanbanwaveStore]);
+  }, [getBoards]);
 
   return (
     <nav

--- a/src/app/components/layout/Nav.tsx
+++ b/src/app/components/layout/Nav.tsx
@@ -1,7 +1,7 @@
 import clsx from 'clsx';
 import { Icon, IconButton } from 'app/components';
 import { Link } from 'react-router-dom';
-import { KWBoard, useKanbanBoardCollection } from 'kanbanwave';
+import { KWBoard, useKanbanwaveStore } from 'kanbanwave';
 import { useEffect, useState } from 'react';
 
 type NavProps = {
@@ -10,14 +10,14 @@ type NavProps = {
 };
 
 const Nav = ({ open, onClickDrawer }: NavProps) => {
-  const boardCollectionStore = useKanbanBoardCollection();
+  const kanbanwaveStore = useKanbanwaveStore();
   const [boards, setBoards] = useState<KWBoard[]>([]);
 
   useEffect(() => {
     (async () => {
-      setBoards(await boardCollectionStore.getBoards());
+      setBoards(await kanbanwaveStore.getBoards());
     })();
-  }, [boardCollectionStore]);
+  }, [kanbanwaveStore]);
 
   return (
     <nav

--- a/src/app/pages/BoardsPage.tsx
+++ b/src/app/pages/BoardsPage.tsx
@@ -16,7 +16,7 @@ import { Link } from 'react-router-dom';
 const BoardsPage = () => {
   const [open, dialogOpen] = useToggle(false);
 
-  const kanbanwaveStore = useKanbanwaveStore();
+  const { createBoard } = useKanbanwaveStore();
 
   const {
     register,
@@ -38,7 +38,7 @@ const BoardsPage = () => {
 
   const handleBoardSubmit = (data: { title: string }) => {
     const { title } = data;
-    kanbanwaveStore.createBoard({ title });
+    createBoard({ title });
     dialogOpen();
     reset();
   };

--- a/src/app/pages/BoardsPage.tsx
+++ b/src/app/pages/BoardsPage.tsx
@@ -1,5 +1,5 @@
 import { useForm } from 'react-hook-form';
-import { BoardCollection, useKanbanBoardCollection } from 'kanbanwave';
+import { BoardCollection, useKanbanwaveStore } from 'kanbanwave';
 import {
   Button,
   Dialog,
@@ -16,7 +16,7 @@ import { Link } from 'react-router-dom';
 const BoardsPage = () => {
   const [open, dialogOpen] = useToggle(false);
 
-  const boardCollectionStore = useKanbanBoardCollection();
+  const kanbanwaveStore = useKanbanwaveStore();
 
   const {
     register,
@@ -38,7 +38,7 @@ const BoardsPage = () => {
 
   const handleBoardSubmit = (data: { title: string }) => {
     const { title } = data;
-    boardCollectionStore.createBoard({ title });
+    kanbanwaveStore.createBoard({ title });
     dialogOpen();
     reset();
   };

--- a/src/kanbanwave/core/storage.ts
+++ b/src/kanbanwave/core/storage.ts
@@ -1,21 +1,26 @@
 import type { KanbanwaveStorage } from './types';
 
+function wrap<Fn extends (...args: any[]) => any>(
+  fn: Fn
+): (...args: Parameters<Fn>) => ReturnType<Fn> {
+  return (...args: Parameters<Fn>): ReturnType<Fn> => fn(...args);
+}
+
 export const makeKanbanwaveStore = (storage: KanbanwaveStorage) => {
   let snapshot = {
-    getBoards: (...args: Parameters<typeof storage.getBoards>) =>
-      storage.getBoards(...args),
-    getBoardContent: (...args: Parameters<typeof storage.getBoardContent>) =>
-      storage.getBoardContent(...args)
+    getBoards: wrap(storage.getBoards),
+    getBoardContent: wrap(storage.getBoardContent)
   };
   let listeners: Array<() => void> = [];
 
-  const emitChanges = () => {
-    snapshot = {
-      getBoards: (...args: Parameters<typeof storage.getBoards>) =>
-        storage.getBoards(...args),
-      getBoardContent: (...args: Parameters<typeof storage.getBoardContent>) =>
-        storage.getBoardContent(...args)
-    };
+  const emitChanges = (changes: Array<keyof typeof snapshot>) => {
+    snapshot = { ...snapshot };
+    changes.forEach(key => {
+      // snapshot[key]에 값(타입)을 올바르게 할당할 수 없어, 잘못된 로직이 들어갈 위험이 있음
+      // 그래서 fn 변수를 선언해, 타입을 미리 검증
+      const fn = wrap(storage[key]) as (typeof snapshot)[typeof key];
+      snapshot[key] = fn as any;
+    });
     for (let listener of listeners) {
       listener();
     }
@@ -33,51 +38,51 @@ export const makeKanbanwaveStore = (storage: KanbanwaveStorage) => {
     },
     createBoard(...args: Parameters<typeof storage.createBoard>) {
       storage.createBoard(...args);
-      emitChanges();
+      emitChanges(['getBoards']);
     },
     updateBoard(...args: Parameters<typeof storage.updateBoard>) {
       storage.updateBoard(...args);
-      emitChanges();
+      emitChanges(['getBoards', 'getBoardContent']);
     },
     deleteBoard(...args: Parameters<typeof storage.deleteBoard>) {
       storage.deleteBoard(...args);
-      emitChanges();
+      emitChanges(['getBoards', 'getBoardContent']);
     },
     createList(...args: Parameters<typeof storage.createList>) {
       storage.createList(...args);
-      emitChanges();
+      emitChanges(['getBoardContent']);
     },
     updateList(...args: Parameters<typeof storage.updateList>) {
       storage.updateList(...args);
-      emitChanges();
+      emitChanges(['getBoardContent']);
     },
     deleteList(...args: Parameters<typeof storage.deleteList>) {
       storage.deleteList(...args);
-      emitChanges();
+      emitChanges(['getBoardContent']);
     },
     reorderList(...args: Parameters<typeof storage.reorderList>) {
       storage.reorderList(...args);
-      emitChanges();
+      emitChanges(['getBoardContent']);
     },
     getCard(...args: Parameters<typeof storage.getCard>) {
       storage.getCard(...args);
-      emitChanges();
+      emitChanges(['getBoardContent']);
     },
     createCard(...args: Parameters<typeof storage.createCard>) {
       storage.createCard(...args);
-      emitChanges();
+      emitChanges(['getBoardContent']);
     },
     updateCard(...args: Parameters<typeof storage.updateCard>) {
       storage.updateCard(...args);
-      emitChanges();
+      emitChanges(['getBoardContent']);
     },
     deleteCard(...args: Parameters<typeof storage.deleteCard>) {
       storage.deleteCard(...args);
-      emitChanges();
+      emitChanges(['getBoardContent']);
     },
     reorderCard(...args: Parameters<typeof storage.reorderCard>) {
       storage.reorderCard(...args);
-      emitChanges();
+      emitChanges(['getBoardContent']);
     }
   };
 };

--- a/src/kanbanwave/core/storage.ts
+++ b/src/kanbanwave/core/storage.ts
@@ -1,6 +1,6 @@
 import type { KanbanwaveStorage } from './types';
 
-export const makeBoardCollectionStore = (storage: KanbanwaveStorage) => {
+export const makeKanbanwaveStore = (storage: KanbanwaveStorage) => {
   let snapshot = {
     getBoards: (...args: Parameters<typeof storage.getBoards>) =>
       storage.getBoards(...args),
@@ -9,7 +9,7 @@ export const makeBoardCollectionStore = (storage: KanbanwaveStorage) => {
   };
   let listeners: Array<() => void> = [];
 
-  const emitChange = () => {
+  const emitChanges = () => {
     snapshot = {
       getBoards: (...args: Parameters<typeof storage.getBoards>) =>
         storage.getBoards(...args),
@@ -33,93 +33,53 @@ export const makeBoardCollectionStore = (storage: KanbanwaveStorage) => {
     },
     createBoard(...args: Parameters<typeof storage.createBoard>) {
       storage.createBoard(...args);
-      emitChange();
+      emitChanges();
     },
     updateBoard(...args: Parameters<typeof storage.updateBoard>) {
       storage.updateBoard(...args);
-      emitChange();
-    },
-    deleteBoard(...args: Parameters<typeof storage.deleteBoard>) {
-      storage.deleteBoard?.(...args);
-      emitChange();
-    }
-  };
-};
-
-export type BoardCollectionStore = ReturnType<typeof makeBoardCollectionStore>;
-
-export const makeBoardViewStore = (storage: KanbanwaveStorage) => {
-  let snapshot = {
-    getBoardContent: (...args: Parameters<typeof storage.getBoardContent>) =>
-      storage.getBoardContent(...args)
-  };
-  let listeners: Array<() => void> = [];
-
-  const emitChange = () => {
-    snapshot = {
-      getBoardContent: (...args: Parameters<typeof storage.getBoardContent>) =>
-        storage.getBoardContent(...args)
-    };
-    for (let listener of listeners) {
-      listener();
-    }
-  };
-
-  return {
-    subscribe(listener: () => void) {
-      listeners = [...listeners, listener];
-      return () => {
-        listeners = listeners.filter(it => it !== listener);
-      };
-    },
-    getSnapshot() {
-      return snapshot;
-    },
-    updateBoard(...args: Parameters<typeof storage.updateBoard>) {
-      storage.updateBoard(...args);
-      emitChange();
+      emitChanges();
     },
     deleteBoard(...args: Parameters<typeof storage.deleteBoard>) {
       storage.deleteBoard(...args);
-      emitChange();
+      emitChanges();
     },
     createList(...args: Parameters<typeof storage.createList>) {
       storage.createList(...args);
-      emitChange();
+      emitChanges();
     },
     updateList(...args: Parameters<typeof storage.updateList>) {
       storage.updateList(...args);
-      emitChange();
+      emitChanges();
     },
     deleteList(...args: Parameters<typeof storage.deleteList>) {
       storage.deleteList(...args);
-      emitChange();
+      emitChanges();
     },
     reorderList(...args: Parameters<typeof storage.reorderList>) {
       storage.reorderList(...args);
-      emitChange();
+      emitChanges();
     },
     getCard(...args: Parameters<typeof storage.getCard>) {
       storage.getCard(...args);
-      emitChange();
+      emitChanges();
     },
     createCard(...args: Parameters<typeof storage.createCard>) {
       storage.createCard(...args);
-      emitChange();
+      emitChanges();
     },
     updateCard(...args: Parameters<typeof storage.updateCard>) {
       storage.updateCard(...args);
-      emitChange();
+      emitChanges();
     },
     deleteCard(...args: Parameters<typeof storage.deleteCard>) {
       storage.deleteCard(...args);
-      emitChange();
+      emitChanges();
     },
     reorderCard(...args: Parameters<typeof storage.reorderCard>) {
       storage.reorderCard(...args);
-      emitChange();
+      emitChanges();
     }
   };
 };
 
-export type BoardViewStore = ReturnType<typeof makeBoardViewStore>;
+export type KanbanwaveStore = ReturnType<typeof makeKanbanwaveStore>;

--- a/src/kanbanwave/core/storage.ts
+++ b/src/kanbanwave/core/storage.ts
@@ -2,13 +2,20 @@ import type { KanbanwaveStorage } from './types';
 
 export const makeBoardCollectionStore = (storage: KanbanwaveStorage) => {
   let snapshot = {
-    getBoards: storage.getBoards,
-    getBoardContent: storage.getBoardContent
+    getBoards: (...args: Parameters<typeof storage.getBoards>) =>
+      storage.getBoards(...args),
+    getBoardContent: (...args: Parameters<typeof storage.getBoardContent>) =>
+      storage.getBoardContent(...args)
   };
   let listeners: Array<() => void> = [];
 
   const emitChange = () => {
-    snapshot = { getBoards: storage.getBoards, getBoardContent: storage.getBoardContent };
+    snapshot = {
+      getBoards: (...args: Parameters<typeof storage.getBoards>) =>
+        storage.getBoards(...args),
+      getBoardContent: (...args: Parameters<typeof storage.getBoardContent>) =>
+        storage.getBoardContent(...args)
+    };
     for (let listener of listeners) {
       listener();
     }
@@ -42,11 +49,17 @@ export const makeBoardCollectionStore = (storage: KanbanwaveStorage) => {
 export type BoardCollectionStore = ReturnType<typeof makeBoardCollectionStore>;
 
 export const makeBoardViewStore = (storage: KanbanwaveStorage) => {
-  let snapshot = { getBoardContent: storage.getBoardContent };
+  let snapshot = {
+    getBoardContent: (...args: Parameters<typeof storage.getBoardContent>) =>
+      storage.getBoardContent(...args)
+  };
   let listeners: Array<() => void> = [];
 
   const emitChange = () => {
-    snapshot = { getBoardContent: storage.getBoardContent };
+    snapshot = {
+      getBoardContent: (...args: Parameters<typeof storage.getBoardContent>) =>
+        storage.getBoardContent(...args)
+    };
     for (let listener of listeners) {
       listener();
     }

--- a/src/kanbanwave/features/BoardCollection.tsx
+++ b/src/kanbanwave/features/BoardCollection.tsx
@@ -2,7 +2,7 @@ import { KWBoard, KWBoardForm } from '../core/types';
 import Board from '../components/Board';
 import NewBoard from '../components/NewBoard';
 import useQuery from '../hooks/useQuery';
-import { useKanbanBoardCollection } from './KanbanStorageProvider';
+import { useKanbanwaveStore } from './KanbanStorageProvider';
 
 type BoardCollectionProps = {
   boardRender?: (provided: {
@@ -18,9 +18,9 @@ type BoardCollectionProps = {
 };
 
 const BoardCollection = ({ boardRender, newBoardRender }: BoardCollectionProps) => {
-  const boardCollectionStore = useKanbanBoardCollection();
+  const kanbanwaveStore = useKanbanwaveStore();
 
-  const { status, data: boards } = useQuery(boardCollectionStore.getBoards, []);
+  const { status, data: boards } = useQuery(kanbanwaveStore.getBoards, []);
 
   if (status === 'pending') {
     return (
@@ -32,11 +32,11 @@ const BoardCollection = ({ boardRender, newBoardRender }: BoardCollectionProps) 
 
   const handleBoardAdd = (title: string) => {
     const board: KWBoardForm = { title };
-    boardCollectionStore.createBoard(board);
+    kanbanwaveStore.createBoard(board);
   };
 
   const makeBoardDeleteClickHandler = (boardId: string) => () => {
-    boardCollectionStore.deleteBoard(boardId);
+    kanbanwaveStore.deleteBoard(boardId);
   };
 
   return (

--- a/src/kanbanwave/features/BoardCollection.tsx
+++ b/src/kanbanwave/features/BoardCollection.tsx
@@ -18,9 +18,9 @@ type BoardCollectionProps = {
 };
 
 const BoardCollection = ({ boardRender, newBoardRender }: BoardCollectionProps) => {
-  const kanbanwaveStore = useKanbanwaveStore();
+  const { getBoards, createBoard, deleteBoard } = useKanbanwaveStore();
 
-  const { status, data: boards } = useQuery(kanbanwaveStore.getBoards, []);
+  const { status, data: boards } = useQuery(getBoards, []);
 
   if (status === 'pending') {
     return (
@@ -32,11 +32,11 @@ const BoardCollection = ({ boardRender, newBoardRender }: BoardCollectionProps) 
 
   const handleBoardAdd = (title: string) => {
     const board: KWBoardForm = { title };
-    kanbanwaveStore.createBoard(board);
+    createBoard(board);
   };
 
   const makeBoardDeleteClickHandler = (boardId: string) => () => {
-    kanbanwaveStore.deleteBoard(boardId);
+    deleteBoard(boardId);
   };
 
   return (

--- a/src/kanbanwave/features/BoardView.tsx
+++ b/src/kanbanwave/features/BoardView.tsx
@@ -39,9 +39,17 @@ const BoardView = ({
   cardRender,
   newCardRender
 }: BoardViewProps) => {
-  const kanbanwaveStore = useKanbanwaveStore();
+  const {
+    getBoardContent,
+    createList,
+    deleteList,
+    reorderList,
+    createCard,
+    deleteCard,
+    reorderCard
+  } = useKanbanwaveStore();
 
-  const { status, data } = useQuery(kanbanwaveStore.getBoardContent, [boardIdProp]);
+  const { status, data } = useQuery(getBoardContent, [boardIdProp]);
 
   if (status === 'pending') {
     return (
@@ -55,11 +63,11 @@ const BoardView = ({
 
   const handleListAdd = (title: string) => {
     const list: KWListForm = { title };
-    kanbanwaveStore.createList(board.id, list);
+    createList(board.id, list);
   };
 
   const makeListDeleteClickHandler = (listId: string) => () => {
-    kanbanwaveStore.deleteList(board.id, listId);
+    deleteList(board.id, listId);
   };
 
   const makeCardAddHandler = (listId: string) => (title: string) => {
@@ -75,11 +83,11 @@ const BoardView = ({
       startDate: date.makeDayMonthYear(currentDate),
       dueDate: date.makeDayMonthYear(currentDate)
     };
-    kanbanwaveStore.createCard(board.id, listId, card);
+    createCard(board.id, listId, card);
   };
 
   const makeCardDeleteClickHandler = (listId: string, cardId: string) => () => {
-    kanbanwaveStore.deleteCard(board.id, listId, cardId);
+    deleteCard(board.id, listId, cardId);
   };
 
   const handleDragEnd = (result: DropResult) => {
@@ -87,9 +95,9 @@ const BoardView = ({
     if (!destination) return;
 
     if (type === KWItemType.LIST) {
-      kanbanwaveStore.reorderList(destination.droppableId, draggableId, destination.index);
+      reorderList(destination.droppableId, draggableId, destination.index);
     } else if (type === KWItemType.CARD) {
-      kanbanwaveStore.reorderCard(
+      reorderCard(
         board.id,
         source.droppableId,
         destination.droppableId,

--- a/src/kanbanwave/features/BoardView.tsx
+++ b/src/kanbanwave/features/BoardView.tsx
@@ -18,7 +18,7 @@ import ListDroppable from '../components/ListDroppable';
 import NewCard from '../components/NewCard';
 import NewList from '../components/NewList';
 import useQuery from '../hooks/useQuery';
-import { useKanbanBoardView } from './KanbanStorageProvider';
+import { useKanbanwaveStore } from './KanbanStorageProvider';
 
 type BoardViewProps = {
   boardId: KWBoardUUID;
@@ -39,9 +39,9 @@ const BoardView = ({
   cardRender,
   newCardRender
 }: BoardViewProps) => {
-  const boardViewStore = useKanbanBoardView();
+  const kanbanwaveStore = useKanbanwaveStore();
 
-  const { status, data } = useQuery(boardViewStore.getBoardContent, [boardIdProp]);
+  const { status, data } = useQuery(kanbanwaveStore.getBoardContent, [boardIdProp]);
 
   if (status === 'pending') {
     return (
@@ -55,11 +55,11 @@ const BoardView = ({
 
   const handleListAdd = (title: string) => {
     const list: KWListForm = { title };
-    boardViewStore.createList(board.id, list);
+    kanbanwaveStore.createList(board.id, list);
   };
 
   const makeListDeleteClickHandler = (listId: string) => () => {
-    boardViewStore.deleteList(board.id, listId);
+    kanbanwaveStore.deleteList(board.id, listId);
   };
 
   const makeCardAddHandler = (listId: string) => (title: string) => {
@@ -75,11 +75,11 @@ const BoardView = ({
       startDate: date.makeDayMonthYear(currentDate),
       dueDate: date.makeDayMonthYear(currentDate)
     };
-    boardViewStore.createCard(board.id, listId, card);
+    kanbanwaveStore.createCard(board.id, listId, card);
   };
 
   const makeCardDeleteClickHandler = (listId: string, cardId: string) => () => {
-    boardViewStore.deleteCard(board.id, listId, cardId);
+    kanbanwaveStore.deleteCard(board.id, listId, cardId);
   };
 
   const handleDragEnd = (result: DropResult) => {
@@ -87,9 +87,9 @@ const BoardView = ({
     if (!destination) return;
 
     if (type === KWItemType.LIST) {
-      boardViewStore.reorderList(destination.droppableId, draggableId, destination.index);
+      kanbanwaveStore.reorderList(destination.droppableId, draggableId, destination.index);
     } else if (type === KWItemType.CARD) {
-      boardViewStore.reorderCard(
+      kanbanwaveStore.reorderCard(
         board.id,
         source.droppableId,
         destination.droppableId,

--- a/src/kanbanwave/features/KanbanStorageProvider.tsx
+++ b/src/kanbanwave/features/KanbanStorageProvider.tsx
@@ -5,17 +5,11 @@ import {
   useMemo,
   useSyncExternalStore
 } from 'react';
-import {
-  BoardCollectionStore,
-  BoardViewStore,
-  makeBoardCollectionStore,
-  makeBoardViewStore
-} from '../core/storage';
+import { KanbanwaveStore, makeKanbanwaveStore } from '../core/storage';
 import { KanbanwaveStorage } from '../core/types';
 
 export type KanbanStorageContextValue = {
-  boardCollection: BoardCollectionStore;
-  boardView: BoardViewStore;
+  store: KanbanwaveStore;
 };
 
 const FALLBACK_STORE = new Proxy(
@@ -30,27 +24,12 @@ const FALLBACK_STORE = new Proxy(
 );
 
 const KanbanStorageContext = createContext<KanbanStorageContextValue>({
-  boardCollection: FALLBACK_STORE as BoardCollectionStore,
-  boardView: FALLBACK_STORE as BoardViewStore
+  store: FALLBACK_STORE as KanbanwaveStore
 });
 
-export const useKanbanBoardCollection = () => {
+export const useKanbanwaveStore = () => {
   const context = useContext(KanbanStorageContext);
-  const store = context.boardCollection;
-  const snapshot = useSyncExternalStore(store.subscribe, store.getSnapshot);
-
-  return useMemo(() => {
-    const { subscribe, getSnapshot, ...methods } = store;
-    return {
-      ...snapshot,
-      ...methods
-    };
-  }, [snapshot, store]);
-};
-
-export const useKanbanBoardView = () => {
-  const context = useContext(KanbanStorageContext);
-  const store = context.boardView;
+  const store = context.store;
   const snapshot = useSyncExternalStore(store.subscribe, store.getSnapshot);
 
   return useMemo(() => {
@@ -68,18 +47,8 @@ type KanbanStorageProviderProps = {
 };
 
 const KanbanStorageProvider = ({ storage, children }: KanbanStorageProviderProps) => {
-  const boardCollectionExternalStore = useMemo(() => makeBoardCollectionStore(storage), [storage]);
-  const boardViewExternalStore = useMemo(
-    () => makeBoardViewStore(storage),
-    [storage]
-  );
-  const contextValue = useMemo(
-    () => ({
-      boardCollection: boardCollectionExternalStore,
-      boardView: boardViewExternalStore
-    }),
-    [boardCollectionExternalStore, boardViewExternalStore]
-  );
+  const store = useMemo(() => makeKanbanwaveStore(storage), [storage]);
+  const contextValue = useMemo(() => ({ store }), [store]);
 
   return (
     <KanbanStorageContext.Provider value={contextValue}>

--- a/src/kanbanwave/index.ts
+++ b/src/kanbanwave/index.ts
@@ -3,8 +3,7 @@ export * from './core/types';
 
 export {
   default as KanbanStorageProvider,
-  useKanbanBoardCollection,
-  useKanbanBoardView,
+  useKanbanwaveStore,
   type KanbanStorageContextValue
 } from './features/KanbanStorageProvider';
 


### PR DESCRIPTION
## Description
- Change snapshot to return new functions.
- Change store snapshot regeneration to be method dependent.
- Combine two stores(`makeBoardCollectionStore`, `makeBoardViewStore`) into one(`makeKanbanwaveStore`).
- Change usage of `useKanbanwaveStore`.
- Fix in which fetcher of useQuery is called unnecessarily.
## What type of PR is this?
- [ ] 🐛 Bug fix
- [ ] 🍕 Feature
- [ ] 🎨 Code style update (formatting, local variables)
- [X] ⚡️ Refactoring (no functional changes, no api changes)
- [ ] 🧹 Chore (non-breaking change which does not affect codebase; Build related changes, version modification, etc.)
- [ ] 🔁 CI related changes
- [ ] 🧪 Test Case
- [ ] 🔥 Performance optimization
- [ ] 📄 Site/documentation update
- [ ] 🤷🏻‍♀️ Other... Please describe:

## Changes made
