### PR TITLE
Feat: implement quick edit functionality for board, list and card titles 

### DIFF
--- a/src/app/components/common/TextArea.tsx
+++ b/src/app/components/common/TextArea.tsx
@@ -1,6 +1,6 @@
 import clsx from 'clsx';
 import { useForkRef } from 'app/hooks';
-import { ChangeEvent, forwardRef, useRef } from 'react';
+import { ChangeEvent, forwardRef, useEffect, useRef } from 'react';
 
 type TextAreaProps = React.ComponentPropsWithoutRef<'textarea'> & {};
 
@@ -21,6 +21,12 @@ const TextArea = forwardRef<HTMLTextAreaElement, TextAreaProps>((props, ref) => 
     onChange?.(e);
     resize();
   };
+
+  useEffect(() => {
+    if (textRef.current) {
+      textRef.current.style.height = `${textRef.current.scrollHeight}px`;
+    }
+  }, []);
 
   return (
     <textarea

--- a/src/app/styles/utilities.css
+++ b/src/app/styles/utilities.css
@@ -30,7 +30,7 @@
   }
 
   .app-base {
-    @apply flex flex-col h-screen py-3.5 pl-10 ml-4;
+    @apply flex flex-col h-screen pb-3.5 pl-8 ml-4;
   }
 
   .list {

--- a/src/kanbanwave/components/Card.tsx
+++ b/src/kanbanwave/components/Card.tsx
@@ -1,51 +1,118 @@
 import { useToggle } from 'app/hooks';
-import { IconButton } from 'app/components';
+import { IconButton, TextArea } from 'app/components';
 import { KWCard } from '../core/types';
 import CardDraggable from './CardDraggable';
+import { useEffect, useRef, useState } from 'react';
 
 type CardProps = {
   card: KWCard;
   cardIndex: number;
   /** @todo cardRender에서 onClick을 주입할 수 있도록 리팩토링 */
   onClick?: (event: React.MouseEvent<HTMLDivElement>) => void;
-  /** @todo edit(save) 버튼 만들어서 이벤트 핸들러에 연결 */
-  onTitleEdit?: (event: React.MouseEvent<HTMLButtonElement>) => void;
+  onTitleSave?: (newTitle: string) => void;
   onDeleteClick?: (event: React.MouseEvent<HTMLButtonElement>) => void;
 };
 
-const Card = ({ card, cardIndex, onClick, onTitleEdit, onDeleteClick }: CardProps) => {
+const Card = ({ card, cardIndex, onClick, onTitleSave, onDeleteClick }: CardProps) => {
   const [open, menuOpen] = useToggle(false);
+  const [isEditing, setIsEditing] = useState(false);
+  const [currentTitle, setCurrentTitle] = useState(card.title);
+  const inputRef = useRef<HTMLTextAreaElement>(null);
+
+  useEffect(() => {
+    if (isEditing && inputRef.current) {
+      inputRef.current.focus();
+    }
+  }, [isEditing]);
+
+  useEffect(() => {
+    setCurrentTitle(card.title);
+  }, [card.title]);
+
   const handleMenuOpen = () => {
     menuOpen();
   };
 
+  const handleTitleSave = () => {
+    setIsEditing(false);
+    if (currentTitle.trim() !== '') {
+      onTitleSave?.(currentTitle);
+    } else {
+      setCurrentTitle(card.title);
+    }
+    handleMenuOpen();
+  };
+
   return (
     <CardDraggable cardId={card.id} cardIndex={cardIndex}>
-      <div
-        className="card group"
-        onClick={e => {
-          onClick?.(e);
-          if (!(e.target instanceof Element)) {
-            return;
-          }
-          if (e.target.closest('[data-event-target="menu-button"]')) {
-            e.preventDefault();
-          }
-        }}>
-        <div className="relative flex items-center justify-between overflow-hidden break-words whitespace-normal">
-          <div className="w-[calc(100%-32px)]">{card.title}</div>
-          <IconButton
-            name="edit"
-            className="single-icon group-hover:flex"
-            onClick={handleMenuOpen}
-            data-event-target="menu-button"
-          />
-        </div>
-      </div>
+      {isEditing ? (
+        <TextArea
+          ref={inputRef}
+          value={currentTitle}
+          onChange={e => setCurrentTitle(e.target.value)}
+          onKeyDown={e => {
+            if (e.key === 'Enter') {
+              handleTitleSave();
+            }
+          }}
+          className="px-2 mb-1 text-lg"
+          autoFocus
+        />
+      ) : (
+        <>
+          <div
+            className="card group"
+            onClick={e => {
+              onClick?.(e);
+              if (!(e.target instanceof Element)) {
+                return;
+              }
+              if (e.target.closest('[data-event-target="menu-button"]')) {
+                e.preventDefault();
+              }
+            }}>
+            <div className="relative flex items-center justify-between overflow-hidden break-words whitespace-normal">
+              <div className="w-[calc(100%-32px)]">{card.title}</div>
+              <IconButton
+                name="edit"
+                className="single-icon group-hover:flex"
+                onClick={handleMenuOpen}
+                data-event-target="menu-button"
+              />
+            </div>
+          </div>
+        </>
+      )}
       {open && (
-        <ul className="flex flex-row justify-around mb-1 menu menu-vertical lg:menu-horizontal bg-base-200 rounded-box">
+        <ul className="flex flex-row justify-around mb-1 menu menu-vertical lg:menu-horizontal">
           <li>
-            <button type="button" onClick={onDeleteClick}>
+            {isEditing ? (
+              <button
+                type="button"
+                onClick={() => {
+                  if (isEditing) {
+                    handleTitleSave();
+                  } else {
+                    handleMenuOpen();
+                  }
+                }}
+                className="text-white bg-zinc-400 rounded-xl">
+                Save card
+              </button>
+            ) : (
+              <button
+                type="button"
+                onClick={() => setIsEditing(true)}
+                className="text-white bg-zinc-400 rounded-xl">
+                Edit card
+              </button>
+            )}
+          </li>
+          <li>
+            <button
+              type="button"
+              onClick={onDeleteClick}
+              className="text-white bg-zinc-400 rounded-xl">
               Delete card
             </button>
           </li>

--- a/src/kanbanwave/components/Card.tsx
+++ b/src/kanbanwave/components/Card.tsx
@@ -3,6 +3,7 @@ import { IconButton, TextArea } from 'app/components';
 import { KWCard } from '../core/types';
 import CardDraggable from './CardDraggable';
 import { useEffect, useRef, useState } from 'react';
+import useDerivedState from '../hooks/useDerivedState';
 
 type CardProps = {
   card: KWCard;
@@ -16,7 +17,7 @@ type CardProps = {
 const Card = ({ card, cardIndex, onClick, onTitleSave, onDeleteClick }: CardProps) => {
   const [open, menuOpen] = useToggle(false);
   const [isEditing, setIsEditing] = useState(false);
-  const [currentTitle, setCurrentTitle] = useState(card.title);
+  const [internalTitle, setInternalTitle] = useDerivedState(card.title);
   const inputRef = useRef<HTMLTextAreaElement>(null);
 
   useEffect(() => {
@@ -25,20 +26,16 @@ const Card = ({ card, cardIndex, onClick, onTitleSave, onDeleteClick }: CardProp
     }
   }, [isEditing]);
 
-  useEffect(() => {
-    setCurrentTitle(card.title);
-  }, [card.title]);
-
   const handleMenuOpen = () => {
     menuOpen();
   };
 
   const handleTitleSave = () => {
     setIsEditing(false);
-    if (currentTitle.trim() !== '') {
-      onTitleSave?.(currentTitle);
+    if (internalTitle.trim() === '') {
+      setInternalTitle(card.title);
     } else {
-      setCurrentTitle(card.title);
+      onTitleSave?.(internalTitle);
     }
     handleMenuOpen();
   };
@@ -48,8 +45,8 @@ const Card = ({ card, cardIndex, onClick, onTitleSave, onDeleteClick }: CardProp
       {isEditing ? (
         <TextArea
           ref={inputRef}
-          value={currentTitle}
-          onChange={e => setCurrentTitle(e.target.value)}
+          value={internalTitle}
+          onChange={e => setInternalTitle(e.target.value)}
           onKeyDown={e => {
             if (e.key === 'Enter') {
               handleTitleSave();
@@ -72,7 +69,7 @@ const Card = ({ card, cardIndex, onClick, onTitleSave, onDeleteClick }: CardProp
               }
             }}>
             <div className="relative flex items-center justify-between overflow-hidden break-words whitespace-normal">
-              <div className="w-[calc(100%-32px)]">{card.title}</div>
+              <div className="w-[calc(100%-32px)]">{internalTitle}</div>
               <IconButton
                 name="edit"
                 className="single-icon group-hover:flex"

--- a/src/kanbanwave/components/List.tsx
+++ b/src/kanbanwave/components/List.tsx
@@ -1,24 +1,64 @@
-import { IconButton, Subtitle } from 'app/components';
+import { IconButton, Subtitle, TextArea } from 'app/components';
 import { KWList } from '../core/types';
 import ListDraggable from './ListDraggable';
+import { useEffect, useRef, useState } from 'react';
 
 type ListProps = {
   children?: React.ReactNode;
   list: KWList;
   listIndex: number;
-  /** @todo edit(save) 버튼 만들어서 이벤트 핸들러에 연결 */
-  onTitleEdit?: (event: React.MouseEvent<HTMLButtonElement>) => void;
   onDeleteClick?: (event: React.MouseEvent<HTMLButtonElement>) => void;
+  onTitleSave?: (newTitle: string) => void;
 };
 
-const List = ({ children, list, listIndex, onDeleteClick, ...props }: ListProps) => {
+const List = ({ children, list, listIndex, onDeleteClick, onTitleSave, ...props }: ListProps) => {
+  const [isEditing, setIsEditing] = useState(false);
+  const [currentTitle, setCurrentTitle] = useState(list.title);
+  const inputRef = useRef<HTMLTextAreaElement>(null);
+
+  useEffect(() => {
+    if (isEditing && inputRef.current) {
+      inputRef.current.focus();
+    }
+  }, [isEditing]);
+
+  useEffect(() => {
+    setCurrentTitle(list.title);
+  }, [list.title]);
+
+  const handleTitleSave = () => {
+    setIsEditing(false);
+    if (currentTitle.trim() !== '') {
+      onTitleSave?.(currentTitle);
+    } else {
+      setCurrentTitle(list.title);
+    }
+  };
+  
   return (
     <ListDraggable listId={list.id} listIndex={listIndex}>
       <div {...props} className="w-64 p-2 mr-2 bg-white rounded-lg shadow-lg h-fit">
         <div className="flex items-center justify-between mb-2">
-          <Subtitle className="flex-1 pl-2 break-all" size="lg">
-            {list.title}
-          </Subtitle>
+          {isEditing ? (
+            <TextArea
+              ref={inputRef}
+              value={currentTitle}
+              onChange={e => setCurrentTitle(e.target.value)}
+              onBlur={handleTitleSave}
+              onKeyDown={e => {
+                if (e.key === 'Enter') handleTitleSave();
+              }}
+              className="px-2 text-lg"
+              autoFocus
+            />
+          ) : (
+            <Subtitle
+              className="flex-1 p-2 break-all cursor-pointer"
+              size="lg"
+              onClick={() => setIsEditing(true)}>
+              {list.title}
+            </Subtitle>
+          )}
           <div className="flex justify-between ml-2">
             <IconButton
               name="remove"

--- a/src/kanbanwave/components/List.tsx
+++ b/src/kanbanwave/components/List.tsx
@@ -2,6 +2,7 @@ import { IconButton, Subtitle, TextArea } from 'app/components';
 import { KWList } from '../core/types';
 import ListDraggable from './ListDraggable';
 import { useEffect, useRef, useState } from 'react';
+import useDerivedState from '../hooks/useDerivedState';
 
 type ListProps = {
   children?: React.ReactNode;
@@ -13,7 +14,7 @@ type ListProps = {
 
 const List = ({ children, list, listIndex, onDeleteClick, onTitleSave, ...props }: ListProps) => {
   const [isEditing, setIsEditing] = useState(false);
-  const [currentTitle, setCurrentTitle] = useState(list.title);
+  const [internalTitle, setInternalTitle] = useDerivedState(list.title);
   const inputRef = useRef<HTMLTextAreaElement>(null);
 
   useEffect(() => {
@@ -22,16 +23,12 @@ const List = ({ children, list, listIndex, onDeleteClick, onTitleSave, ...props 
     }
   }, [isEditing]);
 
-  useEffect(() => {
-    setCurrentTitle(list.title);
-  }, [list.title]);
-
   const handleTitleSave = () => {
     setIsEditing(false);
-    if (currentTitle.trim() !== '') {
-      onTitleSave?.(currentTitle);
+    if (internalTitle.trim() === '') {
+      setInternalTitle(list.title);
     } else {
-      setCurrentTitle(list.title);
+      onTitleSave?.(internalTitle);
     }
   };
   
@@ -42,8 +39,8 @@ const List = ({ children, list, listIndex, onDeleteClick, onTitleSave, ...props 
           {isEditing ? (
             <TextArea
               ref={inputRef}
-              value={currentTitle}
-              onChange={e => setCurrentTitle(e.target.value)}
+              value={internalTitle}
+              onChange={e => setInternalTitle(e.target.value)}
               onBlur={handleTitleSave}
               onKeyDown={e => {
                 if (e.key === 'Enter') handleTitleSave();
@@ -56,7 +53,7 @@ const List = ({ children, list, listIndex, onDeleteClick, onTitleSave, ...props 
               className="flex-1 p-2 break-all cursor-pointer"
               size="lg"
               onClick={() => setIsEditing(true)}>
-              {list.title}
+              {internalTitle}
             </Subtitle>
           )}
           <div className="flex justify-between ml-2">

--- a/src/kanbanwave/features/BoardView.tsx
+++ b/src/kanbanwave/features/BoardView.tsx
@@ -19,6 +19,7 @@ import NewCard from '../components/NewCard';
 import NewList from '../components/NewList';
 import useQuery from '../hooks/useQuery';
 import { useKanbanwaveStore } from './KanbanStorageProvider';
+import useDerivedState from '../hooks/useDerivedState';
 
 type BoardViewProps = {
   boardId: KWBoardUUID;
@@ -60,7 +61,7 @@ const BoardView = ({
     lists: []
   });
   const [isEditing, setIsEditing] = useState(false);
-  const [currentTitle, setCurrentTitle] = useState('');
+  const [internalTitle, setInternalTitle] = useDerivedState('');
   const inputRef = useRef<HTMLInputElement>(null);
 
   useEffect(() => {
@@ -70,8 +71,8 @@ const BoardView = ({
   }, [isEditing]);
 
   useEffect(() => {
-    setCurrentTitle(serverData?.title || '');
-  }, [serverData]);
+    setInternalTitle(serverData?.title || '');
+  }, [serverData?.title, setInternalTitle]);
 
   useEffect(() => {
     if (status === 'resolved') {
@@ -230,10 +231,10 @@ const BoardView = ({
 
   const handleBoardTitleSave = () => {
     setIsEditing(false);
-    if (currentTitle.trim() !== '') {
-      updateBoard({ id: boardIdProp, title: currentTitle });
+    if (internalTitle.trim() === '') {
+      setInternalTitle(data.title);
     } else {
-      setCurrentTitle(data.title);
+      updateBoard({ id: boardIdProp, title: internalTitle });
     }
   };
 
@@ -262,8 +263,8 @@ const BoardView = ({
           {isEditing ? (
             <Input
               ref={inputRef}
-              value={currentTitle}
-              onChange={e => setCurrentTitle(e.target.value)}
+              value={internalTitle}
+              onChange={e => setInternalTitle(e.target.value)}
               onBlur={handleBoardTitleSave}
               onKeyDown={e => {
                 if (e.key === 'Enter') {
@@ -277,7 +278,7 @@ const BoardView = ({
               size="xl"
               className="px-2 font-bold text-white"
               onClick={() => setIsEditing(true)}>
-              {board.title}
+              {internalTitle}
             </Subtitle>
           )}
         </div>

--- a/src/kanbanwave/features/BoardView.tsx
+++ b/src/kanbanwave/features/BoardView.tsx
@@ -47,6 +47,7 @@ const BoardView = ({
     deleteList,
     reorderList,
     createCard,
+    updateCard,
     deleteCard,
     reorderCard
   } = useKanbanwaveStore();
@@ -243,6 +244,16 @@ const BoardView = ({
       updateList(board.id, updatedList);
     }
   };
+     
+  const makeCardTitleSaveHandler = (listId: string, card: KWCard) => (newTitle: string) => {
+    const cardToUpdate = data.lists
+      .find(list => list.id === listId)
+      ?.cards.find(c => c.id === card.id);
+    if (cardToUpdate) {
+      const updatedCard = { ...cardToUpdate, title: newTitle };
+      updateCard(board.id, listId, updatedCard);
+    }
+  }
   
   return (
     <section className="app-base">
@@ -306,7 +317,8 @@ const BoardView = ({
                   const cardProps = {
                     card: card,
                     cardIndex: index,
-                    onDeleteClick: makeCardDeleteClickHandler(list.id, card.id)
+                    onDeleteClick: makeCardDeleteClickHandler(list.id, card.id),
+                    onTitleSave: makeCardTitleSaveHandler(list.id, card)
                   };
                   return (
                     <Fragment key={`${list.id}:${card.id}`}>

--- a/src/kanbanwave/features/BoardView.tsx
+++ b/src/kanbanwave/features/BoardView.tsx
@@ -43,6 +43,7 @@ const BoardView = ({
     getBoardContent,
     updateBoard,
     createList,
+    updateList,
     deleteList,
     reorderList,
     createCard,
@@ -235,6 +236,14 @@ const BoardView = ({
     }
   };
 
+  const makeListTitleSaveHandler = (listId: string) => (newTitle: string) => {
+    const listToUpdate = data.lists.find(list => list.id === listId);
+    if (listToUpdate) {
+      const updatedList = { ...listToUpdate, title: newTitle };
+      updateList(board.id, updatedList);
+    }
+  };
+  
   return (
     <section className="app-base">
       <div className="board-header flex max-w-full w-[calc(100%-23px)] py-3">
@@ -272,7 +281,9 @@ const BoardView = ({
               key={list.id}
               list={list}
               listIndex={index}
-              onDeleteClick={makeListDeleteClickHandler(list.id)}>
+              onDeleteClick={makeListDeleteClickHandler(list.id)}
+              onTitleSave={makeListTitleSaveHandler(list.id)}
+              >
               <CardDroppable
                 listId={list.id}
                 buttonSlot={(() => {

--- a/src/kanbanwave/hooks/useCallbackRef.tsx
+++ b/src/kanbanwave/hooks/useCallbackRef.tsx
@@ -1,0 +1,14 @@
+import { useEffect, useMemo, useRef } from 'react';
+
+function useCallbackRef<T extends (...args: any[]) => any>(callback: T): T {
+  const callbackRef = useRef(callback);
+
+  useEffect(() => {
+    callbackRef.current = callback;
+  });
+
+  // https://github.com/facebook/react/issues/19240
+  return useMemo(() => ((...args: any[]) => callbackRef.current?.(...args)) as T, []);
+}
+
+export default useCallbackRef;

--- a/src/kanbanwave/hooks/useDerivedState.tsx
+++ b/src/kanbanwave/hooks/useDerivedState.tsx
@@ -1,0 +1,22 @@
+import { useEffect, useState } from 'react';
+import useCallbackRef from './useCallbackRef';
+
+function useDerivedState<T>(state: T, factory?: (state: T, item: T) => T): [T, (item: T) => void];
+function useDerivedState<T, I>(state: T, factory: (state: T, item: I) => T): [T, (item: I) => void];
+function useDerivedState<T, I>(state: T, factory?: (state: T, item: T | I) => T) {
+  const [derivedState, setDerivedState] = useState(state);
+
+  const dispatch = useCallbackRef((item: T | I) => {
+    const fallbackFactory = () => item as T;
+    const fn = factory ?? fallbackFactory;
+    setDerivedState(prevState => fn(prevState, item))
+  });
+
+  useEffect(() => {
+    setDerivedState(state);
+  }, [state]);
+
+  return [derivedState, dispatch];
+}
+
+export default useDerivedState;


### PR DESCRIPTION
## Description
- Add feature to edit board, list, card title.
- Add `useCallbackRef` and `useDerivedState` hooks.
- Apply `useDerivedState` hook to `BoardView`, `List` and `Card` components.
## What type of PR is this?
- [ ] 🐛 Bug fix
- [X] 🍕 Feature
- [ ] 🎨 Code style update (formatting, local variables)
- [ ] ⚡️ Refactoring (no functional changes, no api changes)
- [ ] 🧹 Chore (non-breaking change which does not affect codebase; Build related changes, version modification, etc.)
- [ ] 🔁 CI related changes
- [ ] 🧪 Test Case
- [ ] 🔥 Performance optimization
- [ ] 📄 Site/documentation update
- [ ] 🤷🏻‍♀️ Other... Please describe:


## Changes made
